### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "matchzy-auto-tournament",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Tournament management API for CS2 MatchZy plugin",
     "main": "dist/index.js",
     "scripts": {


### PR DESCRIPTION
## Release 1.1.1

This PR bumps the version to 1.1.1 in preparation for release.

### Changes
- Bumped version from 1.1.0 to 1.1.1 in package.json