### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "matchzy-auto-tournament",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "description": "Tournament management API for CS2 MatchZy plugin",
     "main": "dist/index.js",
     "scripts": {


### PR DESCRIPTION
## Release 1.2.0

This PR bumps the version to 1.2.0 in preparation for release.

### Changes
- Bumped version from 1.1.1 to 1.2.0 in package.json