### PR TITLE
feat: add standalone Discord webhook script and auto-updating changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to MatchZy Auto Tournament will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+### Added
+- Features and improvements that are in development
+
+---
+
+## [1.2.0] - 2025-01-XX
+
+### Added
+- Core tournament management platform
+- Automatic bracket generation and server allocation
+- CS Major compliant map veto system
+- Real-time updates and player tracking
+- Admin controls and demo management
+- Public team pages with all match information
+
+---
+
+## [1.0.0] - 2025-01-XX
+
+### Added
+- Initial release
+- Core tournament management platform
+- Automatic bracket generation and server allocation
+- CS Major compliant map veto system
+- Real-time updates and player tracking
+- Admin controls and demo management
+- Public team pages with all match information
+
+---
+
+[Unreleased]: https://github.com/sivert-io/matchzy-auto-tournament/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v1.2.0
+[1.0.0]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v1.0.0
+

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -167,6 +167,7 @@ nav:
       - Architecture: development/architecture.md
       - Contributing: development/contributing.md
       - Testing PRs: development/testing-pr.md
+  - Changelog: changelog.md
   - Roadmap: roadmap.md
 
 # Additional CSS

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -108,19 +108,6 @@ This document outlines the current features available in MatchZy Auto Tournament
 
 ---
 
-## 📅 Version History
-
-**v1.0.0** (Current)
-
-- Core tournament management platform
-- Automatic bracket generation and server allocation
-- CS Major compliant map veto system
-- Real-time updates and player tracking
-- Admin controls and demo management
-- Public team pages with all match information
-
----
-
 <div align="center">
 
 Made with ❤️ for the CS2 community


### PR DESCRIPTION
## Changes

This PR adds:

### Discord Webhook Improvements
- ✅ Standalone `scripts/discord-webhook.sh` script for manual webhook testing
- ✅ Better error handling with field length validation
- ✅ Automatic .env file sourcing
- ✅ Uses merged PR titles instead of individual commits for cleaner changelog

### Changelog Automation
- ✅ New `docs/changelog.md` page following Keep a Changelog format
- ✅ Automatic changelog updates during release process
- ✅ Extracts PR titles from merged PRs between tags
- ✅ Updates links automatically
- ✅ Added to docs navigation

### Other Improvements
- ✅ Both scripts now source .env file automatically
- ✅ Removed old version history from roadmap.md (now in dedicated changelog)

## Testing

The Discord webhook script can be tested manually:
```bash
export DISCORD_WEBHOOK_URL="your-webhook-url"
./scripts/discord-webhook.sh 1.2.0
```

The changelog will be automatically updated on the next release.