### PR TITLE
docs: link MatchZy Enhanced to me.sivert.io

### DIFF
--- a/docs/getting-started/server-setup.md
+++ b/docs/getting-started/server-setup.md
@@ -29,7 +29,7 @@ After completing the guide, verify the plugin is loaded by typing `meta list` in
 
 ### Step 1: Download
 
-**Latest Release:** [MatchZy Enhanced](https://github.com/sivert-io/MatchZy-Enhanced)
+**Latest Release & Docs:** [MatchZy Enhanced](https://me.sivert.io/)
 
 ### Step 2: Install
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Automated tournament management for Counter-Strike 2. Run CS2 tournaments from b
 Designed to work hand-in-hand with:
 
 - **[CS2 Server Manager](https://sivert-io.github.io/cs2-server-manager/)** – multi-server CS2 deployment and management.
-- **[MatchZy Enhanced](https://github.com/sivert-io/MatchZy-Enhanced)** – enhanced MatchZy plugin for in-server automation.
+- **[MatchZy Enhanced](https://me.sivert.io/)** – enhanced MatchZy plugin for in-server automation.
 
 ## What it does
 
@@ -52,7 +52,7 @@ Read the **[Getting Started](getting-started/quick-start.md)** guide for the com
 ## Related projects
 
 - [CS2 Server Manager](https://sivert-io.github.io/cs2-server-manager/) – multi-server CS2 deployment and management.
-- [MatchZy Enhanced](https://github.com/sivert-io/MatchZy-Enhanced) – enhanced MatchZy plugin for in-server automation.
+- [MatchZy Enhanced](https://me.sivert.io/) – enhanced MatchZy plugin for in-server automation.
 
 ---
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -192,7 +192,7 @@ nav:
       - Changelog: changelog.md
       - Roadmap: roadmap.md
       - CS2 Server Manager: https://sivert-io.github.io/cs2-server-manager/
-      - MatchZy Enhanced: https://github.com/sivert-io/MatchZy-Enhanced
+      - MatchZy Enhanced: https://me.sivert.io/
 
 # Additional CSS
 extra_css:


### PR DESCRIPTION
Update all MatchZy Enhanced references in the docs (home, related, server-setup, mkdocs nav) to point to the public site at https://me.sivert.io/ instead of the GitHub repo.