### PR TITLE
chore: bump version to 1.7.6

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,13 @@ Each bullet is tagged with a type such as **[Feature]**, **[Fix]**, **[Docs]**, 
 
 ---
 
+## [1.7.6] - 2026-01-01
+
+### Added
+- Release v1.7.6
+
+---
+
 ## [1.7.5] – 2025-12-30
 
 ### Tournament & Match Management
@@ -120,7 +127,8 @@ Each bullet is tagged with a type such as **[Feature]**, **[Fix]**, **[Docs]**, 
 
 ---
 
-[Unreleased]: https://github.com/sivert-io/matchzy-auto-tournament/compare/v1.7.5...HEAD
+[Unreleased]: https://github.com/sivert-io/matchzy-auto-tournament/compare/v1.7.6...HEAD
+[1.7.6]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v1.7.6
 [1.7.5]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v1.7.5
 [1.2.0]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v1.2.0
 [1.1.1]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v1.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "matchzy-auto-tournament",
-    "version": "1.7.5",
+    "version": "1.7.6",
     "description": "Tournament management API for CS2 MatchZy plugin",
     "private": true,
     "workspaces": [


### PR DESCRIPTION
## Release 1.7.6

This PR bumps the version to 1.7.6 in preparation for release.

### Changes
- Bumped version from 1.7.5 to 1.7.6 in package.json