### PR TITLE
chore: bump version to 2.0.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,13 @@ Each bullet is tagged with a type such as **[Feature]**, **[Fix]**, **[Docs]**, 
 
 ---
 
+## [2.0.0] - 2026-01-22
+
+### Added
+- Release v2.0.0
+
+---
+
 ## [1.7.6] - 2026-01-01
 
 ### Added
@@ -135,7 +142,8 @@ Each bullet is tagged with a type such as **[Feature]**, **[Fix]**, **[Docs]**, 
 
 ---
 
-[Unreleased]: https://github.com/sivert-io/matchzy-auto-tournament/compare/v1.7.6...HEAD
+[Unreleased]: https://github.com/sivert-io/matchzy-auto-tournament/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v2.0.0
 [1.7.6]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v1.7.6
 [1.7.5]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v1.7.5
 [1.2.0]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v1.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "matchzy-auto-tournament",
-    "version": "1.7.6",
+    "version": "2.0.0",
     "description": "Tournament management API for CS2 MatchZy plugin",
     "private": true,
     "workspaces": [


### PR DESCRIPTION
## Release 2.0.0

This PR bumps the version to 2.0.0 in preparation for release.

### Changes
- Bumped version from 1.7.6 to 2.0.0 in package.json