### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,13 @@ Each bullet is tagged with a type such as **[Feature]**, **[Fix]**, **[Docs]**, 
 
 ---
 
+## [2.0.1] - 2026-01-22
+
+### Added
+- Release v2.0.1
+
+---
+
 ## [2.0.0] - 2026-01-22
 
 ### Added
@@ -142,7 +149,8 @@ Each bullet is tagged with a type such as **[Feature]**, **[Fix]**, **[Docs]**, 
 
 ---
 
-[Unreleased]: https://github.com/sivert-io/matchzy-auto-tournament/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/sivert-io/matchzy-auto-tournament/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v2.0.1
 [2.0.0]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v2.0.0
 [1.7.6]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v1.7.6
 [1.7.5]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v1.7.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "matchzy-auto-tournament",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Tournament management API for CS2 MatchZy plugin",
     "private": true,
     "workspaces": [


### PR DESCRIPTION
## Release 2.0.1

This PR bumps the version to 2.0.1 in preparation for release.

### Changes
- Bumped version from 2.0.0 to 2.0.1 in package.json