### PR TITLE
chore: bump version to 2.0.3

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matchzy/api",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "MatchZy Auto Tournament API (backend)",
   "private": true,
   "main": "dist/index.js",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matchzy/client",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "MatchZy Auto Tournament React client",
   "private": true,
   "scripts": {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,13 @@ Each bullet is tagged with a type such as **[Feature]**, **[Fix]**, **[Docs]**, 
 
 ---
 
+## [2.0.3] - 2026-01-24
+
+### Added
+- Release v2.0.3
+
+---
+
 ## [2.0.2] - 2026-01-24
 
 ### Added
@@ -156,7 +163,8 @@ Each bullet is tagged with a type such as **[Feature]**, **[Fix]**, **[Docs]**, 
 
 ---
 
-[Unreleased]: https://github.com/sivert-io/matchzy-auto-tournament/compare/v2.0.2...HEAD
+[Unreleased]: https://github.com/sivert-io/matchzy-auto-tournament/compare/v2.0.3...HEAD
+[2.0.3]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v2.0.3
 [2.0.2]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v2.0.2
 [2.0.1]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v2.0.1
 [2.0.0]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v2.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "matchzy-auto-tournament",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "Tournament management API for CS2 MatchZy plugin",
     "private": true,
     "workspaces": [


### PR DESCRIPTION
## Release 2.0.3

This PR bumps the version to 2.0.3 in preparation for release.

### Changes
- Bumped version from 2.0.2 to 2.0.3 in package.json