### PR TITLE
chore: bump version to 2.0.6

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matchzy/api",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "MatchZy Auto Tournament API (backend)",
   "private": true,
   "main": "dist/index.js",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matchzy/client",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "MatchZy Auto Tournament React client",
   "private": true,
   "scripts": {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,13 @@ Each bullet is tagged with a type such as **[Feature]**, **[Fix]**, **[Docs]**, 
 
 ---
 
+## [2.0.6] - 2026-01-25
+
+### Added
+- Release v2.0.6
+
+---
+
 ## [2.0.5] - 2026-01-25
 
 ### Added
@@ -198,7 +205,8 @@ Each bullet is tagged with a type such as **[Feature]**, **[Fix]**, **[Docs]**, 
 
 ---
 
-[Unreleased]: https://github.com/sivert-io/matchzy-auto-tournament/compare/v2.0.5...HEAD
+[Unreleased]: https://github.com/sivert-io/matchzy-auto-tournament/compare/v2.0.6...HEAD
+[2.0.6]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v2.0.6
 [2.0.5]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v2.0.5
 [2.0.4]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v2.0.4
 [2.0.3]: https://github.com/sivert-io/matchzy-auto-tournament/releases/tag/v2.0.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "matchzy-auto-tournament",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "description": "Tournament management API for CS2 MatchZy plugin",
     "private": true,
     "workspaces": [


### PR DESCRIPTION
## Release 2.0.6

This PR bumps the version to 2.0.6 in preparation for release.

### Changes
- Bumped version from 2.0.5 to 2.0.6 in package.json