### PR TITLE
chore: bump version to 2.0.14

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matchzy/api",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "MatchZy Auto Tournament API (backend)",
   "private": true,
   "main": "dist/index.js",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matchzy/client",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "MatchZy Auto Tournament React client",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "matchzy-auto-tournament",
-    "version": "2.0.13",
+    "version": "2.0.14",
     "description": "Tournament management API for CS2 MatchZy plugin",
     "private": true,
     "workspaces": [


### PR DESCRIPTION
## Release 2.0.14

This PR bumps the version to 2.0.14 in preparation for release.

### Changes
- Bumped version from 2.0.13 to 2.0.14 in package.json