### PR TITLE
Fix veto turn CTA and i18n keys that rendered raw

### DIFF
--- a/api/src/routes/players.ts
+++ b/api/src/routes/players.ts
@@ -26,6 +26,7 @@ import type { TournamentResponse } from '../types/tournament.types';
 import type { MatchConfig } from '../types/match.types';
 import { generateAvatarSvg } from '../generation/avatar';
 import { getEffectiveViewerSteamId } from '../utils/viewerIdentity';
+import { resolveCurrentVetoTurn } from '../utils/vetoContext';
 
 const router = Router();
 
@@ -398,6 +399,7 @@ router.get('/me/match-status', async (req: Request, res: Response) => {
       DbMatchRow & { team1_players?: string | null; team2_players?: string | null }
     >(
       `SELECT m.id, m.slug, m.status, m.config, m.veto_state, m.team1_id, m.team2_id,
+              m.round, m.tournament_id,
               t1.players as team1_players, t2.players as team2_players
        FROM matches m
        LEFT JOIN teams t1 ON m.team1_id = t1.id
@@ -418,6 +420,7 @@ router.get('/me/match-status', async (req: Request, res: Response) => {
         DbMatchRow & { team1_players?: string | null; team2_players?: string | null }
       >(
         `SELECT m.id, m.slug, m.status, m.config, m.veto_state, m.team1_id, m.team2_id,
+                m.round, m.tournament_id,
                 t1.players as team1_players, t2.players as team2_players
          FROM matches m
          LEFT JOIN teams t1 ON m.team1_id = t1.id
@@ -472,7 +475,13 @@ router.get('/me/match-status', async (req: Request, res: Response) => {
       ? (JSON.parse(match.veto_state) as { status?: string; currentTurn?: string })
       : null;
     const vetoCompleted = vetoState?.status === 'completed';
-    const currentTurn = vetoState?.currentTurn ?? null;
+
+    // Do NOT read currentTurn straight off veto_state: that row is only written
+    // once the first action is submitted, so on step 1 it is NULL and the team
+    // that has to act first would be told "waiting for veto" instead of
+    // "your turn". resolveCurrentVetoTurn derives the opening step from the
+    // configured veto order in that case.
+    const currentTurn = vetoCompleted ? null : (await resolveCurrentVetoTurn(match))?.currentTurn ?? null;
 
     if (['loaded', 'live'].includes(match.status)) {
       return res.json({

--- a/api/src/routes/veto.ts
+++ b/api/src/routes/veto.ts
@@ -7,6 +7,7 @@ import type { DbMatchRow, DbTournamentRow } from '../types/database.types';
 import type { TournamentResponse } from '../types/tournament.types';
 import { generateMatchConfig } from '../services/matchConfigBuilder';
 import { getVetoOrder } from '../utils/vetoConfig';
+import { getVetoContext } from '../utils/vetoContext';
 import { settingsService } from '../services/settingsService';
 import { normalizeConfigPlayers } from '../utils/playerTransform';
 import { resolveViewerIdentity } from '../utils/viewerIdentity';
@@ -177,42 +178,6 @@ async function resolveViewerTeamForMatch(
 
   // Ambiguous or not present – treat as spectator for veto security purposes.
   return null;
-}
-
-type VetoContext = {
-  format: 'bo1' | 'bo3' | 'bo5';
-  tournamentMaps: string[];
-  customVetoOrder?: { bo1?: unknown[]; bo3?: unknown[]; bo5?: unknown[] };
-};
-
-/**
- * Resolve format and map pool for veto. Tournament matches use tournament row;
- * manual matches (round === 0, no tournament) use match config.
- */
-async function getVetoContext(match: DbMatchRow): Promise<VetoContext | null> {
-  const isManual = match.round === 0 || match.tournament_id == null;
-
-  if (isManual) {
-    const config = match.config ? (JSON.parse(match.config) as { maplist?: string[]; num_maps?: number }) : {};
-    const maplist = Array.isArray(config.maplist) ? config.maplist : [];
-    const numMaps = config.num_maps === 1 ? 1 : config.num_maps === 3 ? 3 : config.num_maps === 5 ? 5 : 1;
-    const format: 'bo1' | 'bo3' | 'bo5' = numMaps === 1 ? 'bo1' : numMaps === 3 ? 'bo3' : 'bo5';
-    if (maplist.length === 0) return null;
-    return { format, tournamentMaps: maplist };
-  }
-
-  const tournament = await db.queryOneAsync<{ format: string; maps: string; settings: string | null }>(
-    'SELECT format, maps, settings FROM tournament WHERE id = ?',
-    [match.tournament_id]
-  );
-  if (!tournament) return null;
-
-  const tournamentSettings = tournament.settings ? JSON.parse(tournament.settings) : {};
-  return {
-    format: tournament.format as 'bo1' | 'bo3' | 'bo5',
-    tournamentMaps: JSON.parse(tournament.maps),
-    customVetoOrder: tournamentSettings.customVetoOrder,
-  };
 }
 
 /**

--- a/api/src/utils/vetoContext.ts
+++ b/api/src/utils/vetoContext.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared veto context resolution.
+ *
+ * Both the veto routes and the "is it my turn?" endpoint that drives the navbar
+ * CTA need to know which veto order a match runs and whose turn it currently is.
+ * Keeping that in one place stops the two from disagreeing.
+ */
+
+import { db } from '../config/database';
+import type { DbMatchRow } from '../types/database.types';
+import { getVetoOrder, type VetoStep } from './vetoConfig';
+
+export type VetoContext = {
+  format: 'bo1' | 'bo3' | 'bo5';
+  tournamentMaps: string[];
+  customVetoOrder?: { bo1?: unknown[]; bo3?: unknown[]; bo5?: unknown[] };
+};
+
+/**
+ * Resolve format and map pool for veto. Tournament matches use tournament row;
+ * manual matches (round === 0, no tournament) use match config.
+ */
+export async function getVetoContext(match: DbMatchRow): Promise<VetoContext | null> {
+  const isManual = match.round === 0 || match.tournament_id == null;
+
+  if (isManual) {
+    const config = match.config
+      ? (JSON.parse(match.config) as { maplist?: string[]; num_maps?: number })
+      : {};
+    const maplist = Array.isArray(config.maplist) ? config.maplist : [];
+    const numMaps = config.num_maps === 1 ? 1 : config.num_maps === 3 ? 3 : config.num_maps === 5 ? 5 : 1;
+    const format: 'bo1' | 'bo3' | 'bo5' = numMaps === 1 ? 'bo1' : numMaps === 3 ? 'bo3' : 'bo5';
+    if (maplist.length === 0) return null;
+    return { format, tournamentMaps: maplist };
+  }
+
+  const tournament = await db.queryOneAsync<{ format: string; maps: string; settings: string | null }>(
+    'SELECT format, maps, settings FROM tournament WHERE id = ?',
+    [match.tournament_id]
+  );
+  if (!tournament) return null;
+
+  const tournamentSettings = tournament.settings ? JSON.parse(tournament.settings) : {};
+  return {
+    format: tournament.format as 'bo1' | 'bo3' | 'bo5',
+    tournamentMaps: JSON.parse(tournament.maps),
+    customVetoOrder: tournamentSettings.customVetoOrder,
+  };
+}
+
+/**
+ * Whose turn is it, and to do what?
+ *
+ * A veto's state row is only written once the first action is submitted — the
+ * GET endpoint builds the opening state on the fly without persisting it. So for
+ * a match that has not been acted on yet, `veto_state` is NULL and the turn has
+ * to be derived from the configured veto order.
+ *
+ * Reading the turn straight off `veto_state` therefore reports "nobody's turn"
+ * for step 1, which is exactly when the first team needs to be told to act.
+ *
+ * @returns null when the match has no usable veto configuration, or the veto is
+ *          already complete.
+ */
+export async function resolveCurrentVetoTurn(
+  match: DbMatchRow
+): Promise<{ currentTurn: 'team1' | 'team2'; currentAction: VetoStep['action'] } | null> {
+  if (match.veto_state) {
+    try {
+      const state = JSON.parse(match.veto_state) as {
+        status?: string;
+        currentTurn?: 'team1' | 'team2';
+        currentAction?: VetoStep['action'];
+      };
+
+      if (state.status === 'completed') return null;
+      if (state.currentTurn && state.currentAction) {
+        return { currentTurn: state.currentTurn, currentAction: state.currentAction };
+      }
+    } catch {
+      // Fall through and derive from the configured order.
+    }
+  }
+
+  const context = await getVetoContext(match);
+  if (!context) return null;
+
+  const vetoOrder = getVetoOrder(
+    context.format,
+    context.customVetoOrder as { bo1?: VetoStep[]; bo3?: VetoStep[]; bo5?: VetoStep[] } | undefined,
+    context.tournamentMaps.length
+  );
+  if (vetoOrder.length === 0) return null;
+
+  return { currentTurn: vetoOrder[0].team, currentAction: vetoOrder[0].action };
+}

--- a/client/src/components/modals/useCreateManualMatchModal.ts
+++ b/client/src/components/modals/useCreateManualMatchModal.ts
@@ -426,11 +426,11 @@ export function useCreateManualMatchModal({
   const team1DisplayName =
     team1Mode === 'existing'
       ? existingTeam1?.name ?? ''
-      : team1NewName || t('playersTeams.teamMatchHistory.team1');
+      : team1NewName || t('teamMatchHistory.team1');
   const team2DisplayName =
     team2Mode === 'existing'
       ? existingTeam2?.name ?? ''
-      : team2NewName || t('playersTeams.teamMatchHistory.team2');
+      : team2NewName || t('teamMatchHistory.team2');
 
   // Preview the config that would be sent to MatchZy, for review step.
   // Teams are **optional** for manual matches: when no teams are selected,

--- a/client/src/components/veto/VetoInterface.tsx
+++ b/client/src/components/veto/VetoInterface.tsx
@@ -284,8 +284,8 @@ export const VetoInterface: React.FC<VetoInterfaceProps> = ({
   }
 
   // Determine which team is viewing (must be defined before early returns)
-  const team1Name = vetoState.team1Name || propTeam1Name || t('playersTeams.teamMatchHistory.team1');
-  const team2Name = vetoState.team2Name || propTeam2Name || t('playersTeams.teamMatchHistory.team2');
+  const team1Name = vetoState.team1Name || propTeam1Name || t('teamMatchHistory.team1');
+  const team2Name = vetoState.team2Name || propTeam2Name || t('teamMatchHistory.team2');
   const isViewingTeam1 = currentTeamSlug === vetoState.team1Id;
   const isViewingTeam2 = currentTeamSlug === vetoState.team2Id;
 
@@ -398,7 +398,7 @@ export const VetoInterface: React.FC<VetoInterfaceProps> = ({
             {team1Name}
           </Typography>
           <Typography variant="h3" fontWeight={300} color="text.secondary">
-            {t('playersTeams.teamMatchHistory.vs')}
+            {t('teamMatchHistory.vs')}
           </Typography>
           <Typography
             variant="h4"

--- a/client/src/locales/en/translation/serversAdmin.json
+++ b/client/src/locales/en/translation/serversAdmin.json
@@ -186,5 +186,12 @@
       "serverEvents": "Server Events Monitor",
       "appLogs": "Application Logs"
     }
+  },
+  "servers": {
+    "allocation": {
+      "title": "Waiting for an available server",
+      "waiting": "This match will start automatically once servers are free. Servers needed:",
+      "nextPass": "Next allocation attempt in {{seconds}}s"
+    }
   }
 }

--- a/client/src/locales/nb/translation/serversAdmin.json
+++ b/client/src/locales/nb/translation/serversAdmin.json
@@ -186,5 +186,12 @@
       "serverEvents": "Overvåk serverhendelser",
       "appLogs": "Applikasjonslogger"
     }
+  },
+  "servers": {
+    "allocation": {
+      "title": "Venter på en ledig server",
+      "waiting": "Kampen starter automatisk når servere er ledige. Servere som trengs:",
+      "nextPass": "Neste tildelingsforsøk om {{seconds}} s"
+    }
   }
 }

--- a/tests/api/veto.spec.ts
+++ b/tests/api/veto.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { ensureSignedIn, signInViaRequest } from '../helpers/auth';
+import {
+  ensureSignedIn,
+  signInViaRequest,
+  impersonatePlayer,
+  stopImpersonating,
+} from '../helpers/auth';
 import { setupTournament } from '../helpers/tournamentSetup';
 import { createAndStartTournament } from '../helpers/tournaments';
 import { findMatchByTeams } from '../helpers/matches';
@@ -196,6 +201,65 @@ test.describe.serial('Veto API', () => {
     vetoState = await getVetoState(request, match2!.slug, actingSteamIdFor(team1));
     expect(vetoState.pickedMaps[0].sideTeam2).toBe('T');
     expect(vetoState.pickedMaps[0].sideTeam1).toBe('CT');
+  });
+
+  test('should tell the first team it is their turn before any action is taken', {
+    tag: ['@api', '@veto', '@cta'],
+  }, async ({ request }) => {
+    const tournament = await createAndStartTournament(request, {
+      name: `Veto CTA Test ${Date.now()}`,
+      type: 'single_elimination',
+      format: 'bo1',
+      maps,
+      teamIds: [team1Id, team2Id],
+    });
+    expect(tournament).toBeTruthy();
+
+    const match = await findMatchByTeams(request, team1Id, team2Id);
+    expect(match).toBeTruthy();
+
+    // Nothing has been vetoed yet, so matches.veto_state is still NULL. The
+    // navbar CTA must still tell team1's players to act — reading the turn
+    // straight off veto_state reports "waiting" here, which is exactly backwards
+    // for the team that has to move first.
+    expect(await impersonatePlayer(request, actingSteamIdFor(team1))).toBe(true);
+    const first = await (await request.get('/api/players/me/match-status')).json();
+    expect(first.matchSlug).toBe(match!.slug);
+    expect(first.status).toBe('your_turn_veto');
+
+    // Their opponent is correctly told to wait.
+    expect(await impersonatePlayer(request, actingSteamIdFor(team2))).toBe(true);
+    const second = await (await request.get('/api/players/me/match-status')).json();
+    expect(second.status).toBe('waiting_veto');
+
+    // BO1 opens with *two* team1 bans, so after the first the turn stays put.
+    const actions = getCSMajorBO1Actions(team1, team2);
+    expect(await executeVetoActions(request, match!.slug, [actions[0]])).toBeTruthy();
+
+    expect(await impersonatePlayer(request, actingSteamIdFor(team1))).toBe(true);
+    expect((await (await request.get('/api/players/me/match-status')).json()).status).toBe(
+      'your_turn_veto'
+    );
+
+    expect(await impersonatePlayer(request, actingSteamIdFor(team2))).toBe(true);
+    expect((await (await request.get('/api/players/me/match-status')).json()).status).toBe(
+      'waiting_veto'
+    );
+
+    // Team1's second ban hands over to team2.
+    expect(await executeVetoActions(request, match!.slug, [actions[1]])).toBeTruthy();
+
+    expect(await impersonatePlayer(request, actingSteamIdFor(team2))).toBe(true);
+    expect((await (await request.get('/api/players/me/match-status')).json()).status).toBe(
+      'your_turn_veto'
+    );
+
+    expect(await impersonatePlayer(request, actingSteamIdFor(team1))).toBe(true);
+    expect((await (await request.get('/api/players/me/match-status')).json()).status).toBe(
+      'waiting_veto'
+    );
+
+    await stopImpersonating(request);
   });
 
   test('should validate and reject invalid custom veto orders', {


### PR DESCRIPTION
## Summary

Follow-up to #140. Both of these were found by driving the veto flow by hand in a browser rather than by running tests — they are the kind of thing a green suite happily reports as fine.

## The veto turn CTA was backwards for the first move

The navbar CTA (and its snackbar) read the current turn straight off `matches.veto_state`. That row is only written once the **first action is submitted** — `GET /api/veto/:slug` builds the opening state on the fly and deliberately does not persist it.

So before anyone has acted, `veto_state` is `NULL`, `currentTurn` is `null`, and `myTurn` is false for everybody. The team that had to move first was told **"Waiting for veto"** — precisely when it needed to be told to act. The CTA only began working after someone had already guessed and clicked something.

Now the opening step is derived from the configured veto order when no state is stored yet. `getVetoContext` moves out of `routes/veto.ts` into `utils/vetoContext.ts` alongside a new `resolveCurrentVetoTurn()`, so the veto routes and the CTA can't drift on which order a match runs.

The `match-status` queries also needed `m.round` and `m.tournament_id` — the resolver distinguishes tournament matches from manual ones by those, and without them every match looked manual.

**Before / after**, same match, before any action:

| viewer | before | after |
|---|---|---|
| team1 player (acts first) | `waiting_veto` | `your_turn_veto` |
| team2 player | `waiting_veto` | `waiting_veto` |

## i18n keys rendering raw

The veto match header rendered the literal string `playersTeams.teamMatchHistory.vs` between the two team names.

Locale files are spread flat into one bundle (`locales/*/translation/index.ts`), so `playersTeams` is a *filename*, not a key namespace. Four call sites prefixed keys with it and resolved to nothing — `.vs` is on screen for every single veto.

Separately, `servers.allocation.{title,waiting,nextPass}` were never defined in any locale. They drive the "waiting for an available server" alert on the bracket and matches pages — a state every tournament passes through — so all three rendered as raw keys. Added in `en` and `nb`.

I verified the rest by resolving every statically-written `t('...')` key in `client/src` against the merged English bundle. The only remaining unresolved matches are false positives: brackets-viewer uses its own `bracketsViewer` namespace, and `matchesCount` uses i18next plural suffixes.

## Test plan

- [x] Full suite: **91 passed**, 0 failed, 0 skipped
- [x] `eslint .` — 0 errors (8 pre-existing warnings, untouched file)
- [x] New regression test walks a BO1 turn handover, including that the turn correctly *stays* with team1 for their second ban (BO1 opens with two team1 bans — my first version of this test got that wrong and the app was right)
- [x] Walked a full BO3 veto in Chrome: correct turn banners, step counter, banned maps greyed and unclickable, out-of-turn clicks are no-ops, live "opponent made their move" updates, and a final config of `["de_mirage","de_inferno","de_ancient"]` / `["team2_ct","team2_ct","team2_ct"]` matching the choices made

## Not fixed here

Auto-load after veto stalls at "Waiting for Server Assignment" with a fake (`0.0.0.0`) server, because allocation filters on `last_seen IS NULL` and fake servers never check in. That guard is correct for real servers, so I have left it alone — it needs a real server to exercise, and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
