### PR TITLE
Don't leave the container serving 502s when the API dies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -129,18 +129,51 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD node -e "require('http').get('http://localhost:3069/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1) }).on('error', () => process.exit(1))" || exit 1
 
 # Startup script (Node API + Caddy)
+#
+# Both processes are supervised. Previously Caddy ran in the foreground as PID 1
+# with Node backgrounded, so if Node exited -- e.g. it lost the race with
+# Postgres on a host reboot and died with "the database system is starting up"
+# -- the container stayed "up" and Caddy served 502 for every request, forever.
+# The restart policy never fired because the container had not exited, and the
+# healthcheck could only mark it unhealthy.
+#
+# Now the container exits as soon as either process does, so
+# `restart: unless-stopped` can actually recover it.
 RUN printf '%s\n' \
   '#!/bin/sh' \
   'set -e' \
   '' \
-  '# Start Express backend in background' \
+  '# Start Express backend' \
   'node dist/index.js &' \
+  'NODE_PID=$!' \
   '' \
-  '# Wait a moment for backend to start' \
+  '# Give the backend a moment before Caddy starts proxying to it' \
   'sleep 2' \
   '' \
-  '# Start Caddy in foreground' \
-  'exec caddy run --config /app/Caddyfile --adapter caddyfile' \
+  '# Start Caddy' \
+  'caddy run --config /app/Caddyfile --adapter caddyfile &' \
+  'CADDY_PID=$!' \
+  '' \
+  'term() {' \
+  '  kill "$NODE_PID" "$CADDY_PID" 2>/dev/null || true' \
+  '  exit 0' \
+  '}' \
+  'trap term TERM INT' \
+  '' \
+  '# Exit if either process dies, so the container is restarted rather than' \
+  '# left serving 502s from a half-dead stack.' \
+  'while kill -0 "$NODE_PID" 2>/dev/null && kill -0 "$CADDY_PID" 2>/dev/null; do' \
+  '  sleep 5' \
+  'done' \
+  '' \
+  'if kill -0 "$NODE_PID" 2>/dev/null; then' \
+  '  echo "[start.sh] Caddy exited; shutting down so the container restarts." >&2' \
+  'else' \
+  '  echo "[start.sh] Node API exited; shutting down so the container restarts." >&2' \
+  'fi' \
+  '' \
+  'kill "$NODE_PID" "$CADDY_PID" 2>/dev/null || true' \
+  'exit 1' \
   > /app/start.sh && \
   chmod +x /app/start.sh
 


### PR DESCRIPTION
## The bug

Caddy ran in the foreground as PID 1 with Node backgrounded. If Node exited, the container stayed **"up"** and Caddy proxied to a dead upstream — returning 502 for every request, indefinitely. `restart: unless-stopped` never fired, because the container had not exited. The healthcheck could only mark it unhealthy.

I hit this for real while testing. After a Docker Desktop restart the containers came back together and Node lost the race with Postgres:

```
error: the database system is starting up
[ERROR] Failed to initialize database
```

`depends_on: condition: service_healthy` doesn't help — it's only honoured during `docker compose up`, not when the daemon restarts existing containers.

The app then sat unreachable until someone manually restarted the container. From the user's side it just looks like:

> Welcome back — Sign in to get started
> **Failed to load auth providers: 502**

Which is a fairly hostile way to discover your API is dead.

## The fix

Supervise both processes and exit as soon as either dies, so the restart policy can actually recover the container. TERM/INT are forwarded so `docker stop` still shuts down cleanly.

This turns a permanent outage into a restart loop that self-heals as soon as Postgres is ready.

## Verification

Killed Node inside a running container:

```
$ docker exec matchzy-tournament-api sh -c 'kill $(pgrep -f "node dist/index.js")'
$ docker ps -a --format '{{.Names}} | {{.Status}}'
matchzy-tournament-api | Up 9 seconds (healthy)     # uptime reset = it restarted

$ docker logs matchzy-tournament-api | grep start.sh
[start.sh] Node API exited; shutting down so the container restarts.

$ docker inspect ... --format '{{.RestartCount}}'
1

$ curl -s localhost:3069/health
{"status":"ok",...}
```

Before this change the same kill left it `Up 5 minutes (unhealthy)` and 502ing forever.

## Test plan

- [x] Full suite: **91 passed**, 0 failed, 0 skipped
- [x] Container self-heals when Node is killed (above)
- [x] Normal startup unaffected — app healthy, Steam provider loads
- [x] Verified against a real CS2 server end to end (see below)

## Also verified in this session (no code change needed)

With a real server registered — `192.168.50.196:27015`, MatchZy Enhanced 1.4.23, CS2 `1.41.7.8/14178` — the whole post-veto path works, which had never been exercised before:

- Tournament-start CS2 version preflight **passed** against a real RCON `version` response (previously only its failure mode had ever run)
- Veto completed through the UI, allocation ran within ~8s
- RCON sent `matchzy_loadmatch_url "http://192.168.50.181:3069/api/matches/r1m1.json"`
- Match moved to `loaded` / `server_id=cs2-dev-1`
- Config served: `maplist=["de_mirage"]`, `map_sides=["team2_ct"]`, `skip_veto=true`
- **The server actually switched map to de_mirage**, confirmed via RCON `status`

The earlier concern that fake `0.0.0.0` servers are excluded from allocation turned out to be correct behaviour, not a bug — real servers set `last_seen` and are picked up normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
