### PR TITLE
Run the E2E suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,79 @@ jobs:
       # errors are introduced. See scripts/typecheck-ratchet.mjs.
       - name: Typecheck (ratchet)
         run: yarn typecheck:ratchet
+
+  e2e:
+    name: E2E tests
+    runs-on: ubuntu-latest
+    # The image build runs a full yarn install plus a Vite build.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      # The compose stack reads the repo-root .env, both for env_file and for
+      # ${VAR} substitution (hence --env-file below). Building it from
+      # example.env also means CI exercises the documented setup path.
+      #
+      # No STEAM_API_KEY: Steam is left unconfigured on purpose, so the suite has
+      # to hold up with no auth provider enabled.
+      - name: Create .env
+        run: |
+          cp example.env .env
+          {
+            echo "SESSION_SECRET=ci-session-secret"
+            echo "SERVER_TOKEN=server123"
+            echo "ENABLE_TEST_ENDPOINTS=true"
+            echo "STEAM_API_KEY="
+            echo "LOG_LEVEL=info"
+          } >> .env
+
+      - name: Start the stack
+        run: docker compose --env-file .env -f docker/docker-compose.local.yml up -d --build
+
+      - name: Wait for the app
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:3069/health > /dev/null; then
+              echo "app healthy after ${i} attempt(s)"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "App never became healthy." >&2
+          docker compose --env-file .env -f docker/docker-compose.local.yml logs --tail=100
+          exit 1
+
+      - name: Run Playwright
+        env:
+          SKIP_WEBSERVER: '1'
+          PLAYWRIGHT_BASE_URL: http://localhost:3069
+        run: npx playwright test -c tests/playwright.config.ts --reporter=list,html
+
+      # Container logs are usually more informative than the Playwright trace
+      # when the failure is server-side.
+      - name: Dump container logs
+        if: failure()
+        run: docker compose --env-file .env -f docker/docker-compose.local.yml logs --tail=300
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Tear down
+        if: always()
+        run: docker compose --env-file .env -f docker/docker-compose.local.yml down -v

--- a/tests/api/veto-cs-major.spec.ts
+++ b/tests/api/veto-cs-major.spec.ts
@@ -118,7 +118,7 @@ test.describe.serial('CS Major BO1 Veto - API E2E', () => {
             return configResponse.ok();
           },
           {
-            timeout: 5000,
+            timeout: 15000,
             intervals: [100, 250, 500],
           }
         )
@@ -152,7 +152,7 @@ test.describe.serial('CS Major BO1 Veto - API E2E', () => {
               return false;
             },
             {
-              timeout: 5000,
+              timeout: 15000,
               intervals: [500, 1000],
             }
           )
@@ -176,7 +176,7 @@ test.describe.serial('CS Major BO1 Veto - API E2E', () => {
             return configResponse.ok();
           },
           {
-            timeout: 5000,
+            timeout: 15000,
             intervals: [100, 250, 500],
           }
         )
@@ -320,7 +320,7 @@ test.describe.serial('CS Major BO3 Veto - API E2E', () => {
               return false;
             },
             {
-              timeout: 5000,
+              timeout: 15000,
               intervals: [500, 1000],
             }
           )
@@ -339,7 +339,7 @@ test.describe.serial('CS Major BO3 Veto - API E2E', () => {
             return configResponse.ok();
           },
           {
-            timeout: 5000,
+            timeout: 15000,
             intervals: [100, 250, 500],
           }
         )

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -48,6 +48,26 @@ export async function signInViaRequest(
 }
 
 /**
+ * Does this context currently hold an authenticated admin session?
+ *
+ * Asks the API directly. Inferring this from the browser URL is unreliable: the
+ * SPA decides whether to bounce to /login only after it has bootstrapped and
+ * called /api/auth/admin/me, so straight after a `domcontentloaded` navigation
+ * the URL still reads as the requested page for a session that is about to be
+ * rejected.
+ */
+export async function isAdminAuthenticated(request: APIRequestContext): Promise<boolean> {
+  try {
+    const response = await request.get('/api/auth/admin/me');
+    if (!response.ok()) return false;
+    const data = (await response.json()) as { authenticated?: boolean };
+    return data.authenticated === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Sign in via a test-only admin endpoint that creates a Passport session.
  *
  * This bypasses the real SSO flow but still uses the same session mechanism
@@ -57,29 +77,30 @@ export async function signIn(page: Page): Promise<boolean> {
   const ok = await signInViaRequest(page.request);
   if (!ok) return false;
 
-  // Navigate to dashboard; the session cookie should be sent automatically.
+  // Confirm against the API rather than the resulting URL — see
+  // isAdminAuthenticated for why the URL cannot be trusted here.
+  if (!(await isAdminAuthenticated(page.request))) return false;
+
   await page.goto('/');
   await page.waitForLoadState('domcontentloaded');
-
-  return !page.url().includes('/login');
+  return true;
 }
 
 /**
- * Ensure user is signed in (checks first, signs in if needed)
- * @param page Playwright page
+ * Ensure the page holds an admin session, signing in only if it does not.
  */
 export async function ensureSignedIn(page: Page): Promise<void> {
-  await page.goto('/');
-  await page.waitForLoadState('domcontentloaded');
-
-  const currentUrl = page.url();
-  if (!currentUrl.includes('/login')) {
-    // Already signed in
-    return;
+  if (!(await isAdminAuthenticated(page.request))) {
+    const ok = await signIn(page);
+    expect(ok, 'admin sign-in should succeed').toBe(true);
+  } else {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
   }
 
-  const ok = await signIn(page);
-  expect(ok).toBe(true);
+  // The SPA redirects to /login asynchronously once it has checked the session,
+  // so assert on the settled URL rather than whatever it is right now.
+  await expect(page).not.toHaveURL(/\/login/);
 }
 
 /**

--- a/tests/helpers/tournamentSetup.ts
+++ b/tests/helpers/tournamentSetup.ts
@@ -85,47 +85,24 @@ async function ensureTeams(
   count: number,
   prefix: string
 ): Promise<Team[]> {
-  // Try to get existing teams first
-  try {
-    const response = await request.get('/api/teams', {
-      headers: getAuthHeader(),
-    });
-    if (response.ok()) {
-      const data = await response.json();
-      const existingTeams: Team[] = data.teams || [];
-
-      // Reuse a leftover team only if it can actually play a match:
-      //
-      //  - every player must have a real 17-digit Steam ID. Some specs (shuffle)
-      //    create players with synthetic ids like `match-test-player-3-...`;
-      //    those cannot sign in, be impersonated, or take veto turns.
-      //  - the two teams must have disjoint rosters. A match whose teams share a
-      //    Steam ID is unusable: the veto API cannot tell which side that player
-      //    acts for and rejects every action as "not on one of the
-      //    participating teams".
-      const isSteamId = (value: string) => /^\d{17}$/.test(value);
-
-      const picked: Team[] = [];
-      const claimed = new Set<string>();
-
-      for (const team of existingTeams) {
-        const steamIds = (team.players ?? []).map((player) => player.steamId);
-        if (steamIds.length === 0) continue;
-        if (!steamIds.every(isSteamId)) continue;
-        if (steamIds.some((steamId) => claimed.has(steamId))) continue;
-
-        steamIds.forEach((steamId) => claimed.add(steamId));
-        picked.push(team);
-        if (picked.length === count) break;
-      }
-
-      if (picked.length >= count) {
-        return picked.slice(0, count);
-      }
-    }
-  } catch (error) {
-    // Ignore errors, will create new teams
-  }
+  // Always create fresh teams. Reusing whatever teams happen to exist has
+  // repeatedly poisoned other specs, because "a team that exists" is not the
+  // same as "a team that can play a match":
+  //
+  //   - shuffle specs create players with synthetic ids (match-test-player-3-...)
+  //     that can never sign in or be impersonated;
+  //   - the teams UI spec creates a team whose only member (76561198000000000)
+  //     has no player row behind it;
+  //   - leaked duplicates could hand a match two teams with identical rosters,
+  //     which the veto API correctly rejects as ambiguous.
+  //
+  // Each of those was previously patched with a narrower reuse filter. The
+  // filters kept missing cases, so the reuse itself is the problem. Creating a
+  // fresh pair costs two API calls and makes setup deterministic.
+  //
+  // Rosters are disjoint within a pair, which is all the veto API requires; the
+  // same Steam IDs appearing on teams from earlier calls is harmless because
+  // team membership is only ever resolved against the two teams in a match.
 
   // Real Steam IDs for testing avatars - public profiles that should exist
   // These will cycle through as needed for multiple teams

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -26,11 +26,21 @@ export default defineConfig({
     ['html', { outputFolder: '../playwright-report', open: 'never' }],
     ['list'],
   ],
+  /* CI runners are markedly slower than a dev machine. Every E2E failure in the
+     first CI run was a 5s assertion timeout (Playwright's default) rather than a
+     logic error — 13 more tests only passed on retry. Give CI real headroom;
+     keep local runs snappy so a genuine hang still surfaces quickly. */
+  expect: {
+    timeout: process.env.CI ? 15_000 : 5_000,
+  },
+
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3069',
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    actionTimeout: process.env.CI ? 15_000 : 0,
+    navigationTimeout: process.env.CI ? 30_000 : 0,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },

--- a/tests/ui/dashboard.spec.ts
+++ b/tests/ui/dashboard.spec.ts
@@ -29,7 +29,7 @@ test.describe.serial('Dashboard Page', () => {
       expect(page.url()).toContain('/');
 
       // Verify dashboard page loaded
-      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 15000 });
     }
   );
 });

--- a/tests/ui/login-providers-error.spec.ts
+++ b/tests/ui/login-providers-error.spec.ts
@@ -37,7 +37,7 @@ test.describe.serial('Login providers error', () => {
       });
 
       await page.goto('/login', { waitUntil: 'domcontentloaded' });
-      await expect(page.getByText(message)).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText(message)).toBeVisible({ timeout: 15000 });
     }
   );
 });

--- a/tests/ui/maps.spec.ts
+++ b/tests/ui/maps.spec.ts
@@ -34,7 +34,7 @@ test.describe.serial('Maps UI', () => {
 
       // Wait for modal to appear
       const modal = page.getByTestId('map-modal');
-      await expect(modal).toBeVisible({ timeout: 5000 });
+      await expect(modal).toBeVisible({ timeout: 15000 });
 
       // Wait for form fields to be ready
       await page.waitForTimeout(500);
@@ -67,7 +67,7 @@ test.describe.serial('Maps UI', () => {
       if (!modalStillOpen) {
         // Modal closed after error, reopen it
         await addButton.click();
-        await expect(page.getByTestId('map-modal')).toBeVisible({ timeout: 5000 });
+        await expect(page.getByTestId('map-modal')).toBeVisible({ timeout: 15000 });
         await page.waitForTimeout(500);
       }
 
@@ -79,8 +79,8 @@ test.describe.serial('Maps UI', () => {
       const displayNameInput = page.getByTestId('map-display-name-input');
 
       // Wait for inputs to be ready
-      await expect(mapIdInput).toBeVisible({ timeout: 5000 });
-      await expect(displayNameInput).toBeVisible({ timeout: 5000 });
+      await expect(mapIdInput).toBeVisible({ timeout: 15000 });
+      await expect(displayNameInput).toBeVisible({ timeout: 15000 });
 
       // Clear and fill - use fill with empty string first to clear, then fill with new value
       await mapIdInput.fill(''); // Clear by filling empty
@@ -100,7 +100,7 @@ test.describe.serial('Maps UI', () => {
           )
           .catch(() => null),
         freshSubmitButton
-          .click({ timeout: 5000 })
+          .click({ timeout: 15000 })
           .catch(() => freshSubmitButton.click({ force: true })),
       ]);
 
@@ -120,7 +120,7 @@ test.describe.serial('Maps UI', () => {
       if (cardCount > 0) {
         await mapCards.first().click();
         const actionsModal = page.getByTestId('map-actions-modal');
-        await expect(actionsModal).toBeVisible({ timeout: 5000 });
+        await expect(actionsModal).toBeVisible({ timeout: 15000 });
 
         const editButton = page.getByTestId('map-edit-button');
         const editVisible = await editButton.isVisible().catch(() => false);

--- a/tests/ui/matches.spec.ts
+++ b/tests/ui/matches.spec.ts
@@ -26,7 +26,7 @@ test.describe.serial('Matches UI', () => {
       await page.waitForLoadState('networkidle');
 
       // Verify matches page loaded
-      await expect(page.getByTestId('matches-page')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByTestId('matches-page')).toBeVisible({ timeout: 15000 });
     }
   );
 

--- a/tests/ui/players.spec.ts
+++ b/tests/ui/players.spec.ts
@@ -29,7 +29,7 @@ test.describe.serial('Player Management UI', () => {
       await page.waitForLoadState('networkidle');
 
       // Verify players page loaded
-      await expect(page.getByTestId('players-page')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByTestId('players-page')).toBeVisible({ timeout: 15000 });
       expect(page.url()).toContain('/players');
     }
   );
@@ -51,7 +51,7 @@ test.describe.serial('Player Management UI', () => {
 
         // Wait for modal
         const modal = page.getByTestId('player-modal');
-        await expect(modal).toBeVisible({ timeout: 5000 });
+        await expect(modal).toBeVisible({ timeout: 15000 });
 
         // Fill in player details
         const timestamp = Date.now();
@@ -93,7 +93,7 @@ test.describe.serial('Player Management UI', () => {
       await page.waitForLoadState('networkidle');
 
       // Verify players page loaded
-      await expect(page.getByTestId('players-page')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByTestId('players-page')).toBeVisible({ timeout: 15000 });
       expect(page.url()).toContain('/players');
 
       // Player list may be empty or populated
@@ -132,7 +132,7 @@ test.describe.serial('Player Management UI', () => {
         // Wait for edit modal
         const modal = page.getByTestId('player-modal');
         if (await modal.isVisible().catch(() => false)) {
-          await expect(modal).toBeVisible({ timeout: 5000 });
+          await expect(modal).toBeVisible({ timeout: 15000 });
 
           // Find Skill Rating field and update it
           const eloField = page.getByTestId('player-elo-input');

--- a/tests/ui/public-pages.spec.ts
+++ b/tests/ui/public-pages.spec.ts
@@ -81,7 +81,7 @@ test.describe.serial('Public Pages UI', () => {
       }
 
       // Wait for find player form
-      await expect(page.getByTestId('find-player-form')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByTestId('find-player-form')).toBeVisible({ timeout: 15000 });
 
       // Enter Steam ID
       const input = page.getByTestId('find-player-input');
@@ -122,7 +122,7 @@ test.describe.serial('Public Pages UI', () => {
       await page.waitForTimeout(1000);
 
       // Verify public player page loaded
-      await expect(page.getByTestId('public-player-page')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByTestId('public-player-page')).toBeVisible({ timeout: 15000 });
       expect(page.url()).toContain(`/player/${player.id}`);
     }
   );
@@ -141,7 +141,7 @@ test.describe.serial('Public Pages UI', () => {
 
       // Look for error message
       const errorMessage = page.getByTestId('player-not-found-error');
-      await expect(errorMessage).toBeVisible({ timeout: 5000 });
+      await expect(errorMessage).toBeVisible({ timeout: 15000 });
     }
   );
 });

--- a/tests/ui/servers.spec.ts
+++ b/tests/ui/servers.spec.ts
@@ -67,7 +67,7 @@ test.describe.serial('Server UI', () => {
             { timeout: 15000 }
           )
           .catch(() => null),
-        submitButton.click({ timeout: 5000 }),
+        submitButton.click({ timeout: 15000 }),
       ]);
 
       // Wait for modal to close
@@ -76,7 +76,7 @@ test.describe.serial('Server UI', () => {
 
       // Step 2: Verify server appears in UI
       const serverCard = page.getByTestId(`server-card-${serverName.replace(/\s+/g, '-').toLowerCase()}`);
-      await expect(serverCard).toBeVisible({ timeout: 5000 });
+      await expect(serverCard).toBeVisible({ timeout: 15000 });
 
       // Verify server details are visible
       const serverHostInList = serverCard.getByTestId('server-host');
@@ -123,7 +123,7 @@ test.describe.serial('Server UI', () => {
           await page.waitForLoadState('networkidle');
 
           // Verify server is no longer visible
-          await expect(serverCard).not.toBeVisible({ timeout: 5000 });
+          await expect(serverCard).not.toBeVisible({ timeout: 15000 });
         }
       }
     }

--- a/tests/ui/settings.spec.ts
+++ b/tests/ui/settings.spec.ts
@@ -30,10 +30,10 @@ test.describe.serial('Settings UI', () => {
       await page.waitForLoadState('networkidle');
 
       // Check for webhook URL input
-      await expect(page.getByTestId('settings-webhook-url-input')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByTestId('settings-webhook-url-input')).toBeVisible({ timeout: 15000 });
 
       // Save control is present
-      await expect(page.getByTestId('settings-save-button')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByTestId('settings-save-button')).toBeVisible({ timeout: 15000 });
 
       // The Steam API key is env-only; a field here would mean a secret is being
       // round-tripped through the browser.
@@ -50,7 +50,7 @@ test.describe.serial('Settings UI', () => {
       await page.waitForLoadState('networkidle');
 
       const webhookInput = page.getByTestId('settings-webhook-url-input');
-      await expect(webhookInput).toBeVisible({ timeout: 5000 });
+      await expect(webhookInput).toBeVisible({ timeout: 15000 });
 
       // --- Update webhook URL (auto-saved on change/blur) ---
       const testWebhookUrl = `https://example.com/webhook/${Date.now()}`;
@@ -72,7 +72,7 @@ test.describe.serial('Settings UI', () => {
 
       // --- Clear webhook URL and verify the empty value persists ---
       const webhookInput2 = page.getByTestId('settings-webhook-url-input');
-      await expect(webhookInput2).toBeVisible({ timeout: 5000 });
+      await expect(webhookInput2).toBeVisible({ timeout: 15000 });
       await webhookInput2.clear();
       await webhookInput2.blur();
 

--- a/tests/ui/shuffle-tournament.spec.ts
+++ b/tests/ui/shuffle-tournament.spec.ts
@@ -74,7 +74,7 @@ test.describe.serial('Shuffle Tournament UI', () => {
       await page.waitForLoadState('networkidle');
       
       // Verify tournament page loaded
-      await expect(page.getByTestId('tournament-page')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByTestId('tournament-page')).toBeVisible({ timeout: 15000 });
       expect(page.url()).toContain('/tournament');
     }
   );

--- a/tests/ui/teams.spec.ts
+++ b/tests/ui/teams.spec.ts
@@ -42,7 +42,7 @@ test.describe.serial('Teams UI', () => {
       await page.waitForTimeout(500);
 
       // Verify teams page loaded
-      await expect(page.getByTestId('teams-page')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByTestId('teams-page')).toBeVisible({ timeout: 15000 });
       
       // Should have create/add button
       const createButton = page.getByTestId('add-team-button');
@@ -114,13 +114,13 @@ test.describe.serial('Teams UI', () => {
 
       // Click the Add button to add the player
       const addPlayerButton = page.getByTestId('team-add-player-button');
-      await expect(addPlayerButton).toBeVisible({ timeout: 5000 });
+      await expect(addPlayerButton).toBeVisible({ timeout: 15000 });
       await addPlayerButton.click();
       await page.waitForTimeout(1000);
 
       // Verify player was added (check that player count increased to 1 and error is gone)
       const playersHeading = page.getByTestId('team-players-count');
-      await expect(playersHeading).toContainText(/1/, { timeout: 5000 });
+      await expect(playersHeading).toContainText(/1/, { timeout: 15000 });
 
       // Also verify the "No players added yet" alert is gone
       const noPlayersAlert = page.getByTestId('team-no-players-alert');
@@ -142,7 +142,7 @@ test.describe.serial('Teams UI', () => {
             { timeout: 15000 }
           )
           .catch(() => null),
-        submitButton.click({ timeout: 5000 }).catch(() => submitButton.click({ force: true })),
+        submitButton.click({ timeout: 15000 }).catch(() => submitButton.click({ force: true })),
       ]);
 
       // Verify the API call succeeded
@@ -194,7 +194,7 @@ test.describe.serial('Teams UI', () => {
 
         // Verify updated name appears
         const updatedTeamCard = page.getByTestId(`team-card-${updatedName.replace(/\s+/g, '-').toLowerCase()}`);
-        await expect(updatedTeamCard).toBeVisible({ timeout: 5000 });
+        await expect(updatedTeamCard).toBeVisible({ timeout: 15000 });
       }
 
       // Step 4: Delete team via UI
@@ -246,7 +246,7 @@ test.describe.serial('Teams UI', () => {
             await page.waitForLoadState('networkidle');
 
             // Verify team is no longer visible
-            await expect(finalTeamCard).not.toBeVisible({ timeout: 5000 });
+            await expect(finalTeamCard).not.toBeVisible({ timeout: 15000 });
           }
         }
       }

--- a/tests/ui/tournament.spec.ts
+++ b/tests/ui/tournament.spec.ts
@@ -26,7 +26,7 @@ test.describe.serial('Tournament UI', () => {
       await page.waitForLoadState('networkidle');
 
       // Verify tournament page loaded
-      await expect(page.getByTestId('tournament-page')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByTestId('tournament-page')).toBeVisible({ timeout: 15000 });
 
       // Check for tournament form elements - form might be visible if no tournament exists
       const nameInput = page.getByTestId('tournament-name-input');


### PR DESCRIPTION
## Why

The suite existed but nothing ran it automatically. That's how it drifted to 14 passing / 5 failing / 51 skipped — nobody was watching. #140 got it to 90 passing; this keeps it there.

Follow-up to #143, which added the lint + typecheck job. This adds the E2E job to the same workflow.

## Why Docker Compose rather than a leaner CI-only setup

The app can't be served without Caddy. Express only mounts the SPA under `/app/*`, and the tests navigate to `/`, `/players`, `/player/:id` — Caddy is what serves the SPA at the root on `:3069`.

I could have added a root-level static handler to Express just for CI, but standing up a second, divergent way to run the app is a worse trade than the extra build minutes. This runs the same stack developers run locally via `yarn test`.

The `.env` is built from `example.env`, so CI also exercises the documented setup path from a clean checkout — which is exactly where the two `env_file` bugs in #140 came from.

## No Steam key on purpose

`STEAM_API_KEY` is left empty. With no key the Steam provider is disabled and the login page renders no sign-in button at all, so this keeps the suite honest about not assuming a configured auth provider.

That isn't theoretical — it's what caught the stale login assertions in #140, which had been asserting a pre-SSO API-token form.

Rehearsed locally against a stack with the key blanked:

```
91 passed (2.9m)
```

## Failure output

Container logs are dumped on failure, since a server-side failure is usually easier to read there than in a Playwright trace. The HTML report uploads either way, pass or fail.

## Test plan

- [x] Full suite passes with `STEAM_API_KEY` blanked — the exact CI condition (91 passed)
- [x] Workflow YAML parses; both jobs resolve
- [ ] CI run on this PR — the real verification, since the runner is the environment being targeted

Watching the run; will report back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
