### PR TITLE
fix(client): cut type errors 289 → 96, surfacing two real bugs

### DIFF
--- a/client/src/brackets-viewer/main.ts
+++ b/client/src/brackets-viewer/main.ts
@@ -40,11 +40,9 @@ export class BracketsViewer {
         return this.config.customRoundName?.(info, lang.t) || fallbackGetter(info, lang.t);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    private _onMatchClick: MatchClickCallback = (match: MatchWithMetadata): void => { };
+    private _onMatchClick: MatchClickCallback = (_match: MatchWithMetadata): void => { };
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    private _onMatchLabelClick: MatchClickCallback = (match: MatchWithMetadata): void => { };
+    private _onMatchLabelClick: MatchClickCallback = (_match: MatchWithMetadata): void => { };
 
     /**
      * @deprecated Use `onMatchClick` in the `config` parameter of `viewer.render()`.

--- a/client/src/components/dashboard/DashboardStats.tsx
+++ b/client/src/components/dashboard/DashboardStats.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Grid from '@mui/material/Grid';
 import { Card, CardContent, Typography, Chip, CircularProgress, Alert, Box, Stack } from '@mui/material';
 import { useTheme } from '@mui/material/styles';

--- a/client/src/components/dashboard/MatchStatusChart.tsx
+++ b/client/src/components/dashboard/MatchStatusChart.tsx
@@ -94,7 +94,7 @@ export default function MatchStatusChart({
             {
               scaleType: 'point',
               data: data.slice(0, matchData.length),
-              tickInterval: (index, i) => (i + 1) % 5 === 0,
+              tickInterval: (_value, i) => (i + 1) % 5 === 0,
               height: 24,
             },
           ]}

--- a/client/src/components/dashboard/TournamentInfoCard.tsx
+++ b/client/src/components/dashboard/TournamentInfoCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Card,
   CardContent,

--- a/client/src/components/maps/MapCard.tsx
+++ b/client/src/components/maps/MapCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Card, CardContent, Typography, Box } from '@mui/material';
 import MapIcon from '@mui/icons-material/Map';
 import type { Map } from '../../types/api.types';

--- a/client/src/components/maps/MapPoolCard.tsx
+++ b/client/src/components/maps/MapPoolCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Card, CardContent, Typography, Box, Chip } from '@mui/material';
 import type { MapPool, Map as MapType } from '../../types/api.types';
 

--- a/client/src/components/maps/MapPoolsTab.tsx
+++ b/client/src/components/maps/MapPoolsTab.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Grid } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import CollectionsIcon from '@mui/icons-material/Collections';

--- a/client/src/components/maps/MapsTab.tsx
+++ b/client/src/components/maps/MapsTab.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Grid } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import MapIcon from '@mui/icons-material/Map';

--- a/client/src/components/match/MapChipList.tsx
+++ b/client/src/components/match/MapChipList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Box, Chip } from '@mui/material';
 import type { MatchMapResult } from '../../types';
 import { getMapDisplayName } from '../../constants/maps';

--- a/client/src/components/match/MapDemoDownloads.tsx
+++ b/client/src/components/match/MapDemoDownloads.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Box, Button, Stack, Typography, Divider } from '@mui/material';
 import DownloadIcon from '@mui/icons-material/Download';
 import type { MatchMapResult } from '../../types';

--- a/client/src/components/match/MatchNotificationAudio.tsx
+++ b/client/src/components/match/MatchNotificationAudio.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import type { NotificationSoundValue } from '../../utils/soundNotification';
 
 interface MatchNotificationAudioProps {

--- a/client/src/components/match/PlayerRoster.tsx
+++ b/client/src/components/match/PlayerRoster.tsx
@@ -47,7 +47,7 @@ export const PlayerRoster: React.FC<PlayerRosterProps> = ({
     return (
       <Paper variant="outlined" sx={{ p: 2 }}>
         <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-          <Typography variant="h6" fontWeight={600}>
+          <Typography variant="h6" fontWeight={600} color={`${teamColor}.main`}>
             {teamName}
           </Typography>
           {isYourTeam && <Chip label="Your Team" color="primary" size="small" />}

--- a/client/src/components/modals/BatchServerModal.tsx
+++ b/client/src/components/modals/BatchServerModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -118,7 +118,6 @@ export default function BatchServerModal({
   );
   const [password, setPassword] = useState('');
   const [enabled, setEnabled] = useState(true);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [error, setError] = useState('');
   const [saving, setSaving] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -439,6 +438,12 @@ export default function BatchServerModal({
       </DialogTitle>
       <DialogContent sx={{ px: 3, pt: 2, pb: 1 }}>
         <Stack spacing={3}>
+          {error && (
+            <Alert severity="error" data-testid="batch-server-modal-error">
+              {error}
+            </Alert>
+          )}
+
           <Alert severity="info">
             {t('batchServerModal.info')}
           </Alert>

--- a/client/src/components/modals/EloTemplateEditorModal.tsx
+++ b/client/src/components/modals/EloTemplateEditorModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,

--- a/client/src/components/modals/MapActionsModal.tsx
+++ b/client/src/components/modals/MapActionsModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Dialog,
   DialogTitle,

--- a/client/src/components/modals/MapPoolActionsModal.tsx
+++ b/client/src/components/modals/MapPoolActionsModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Dialog,
   DialogTitle,

--- a/client/src/components/modals/MapPoolModal.tsx
+++ b/client/src/components/modals/MapPoolModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,

--- a/client/src/components/modals/MatchDetailsModal.tsx
+++ b/client/src/components/modals/MatchDetailsModal.tsx
@@ -70,7 +70,19 @@ interface MatchDetailsModalProps {
   onDeleted?: (slug: string) => void;
 }
 
-const InnerMatchDetailsModal: React.FC<Required<MatchDetailsModalProps>> = ({
+/**
+ * The inner component runs only once the wrapper below has established that a
+ * match exists, so `match` is non-null here.
+ *
+ * `Required<T>` alone was not enough: it strips `?`, not `| null`, so every one
+ * of the ~125 `match.` dereferences in this component was a type error that the
+ * build never surfaced (esbuild strips types without checking them).
+ */
+type InnerMatchDetailsModalProps = Omit<Required<MatchDetailsModalProps>, 'match'> & {
+  match: Match;
+};
+
+const InnerMatchDetailsModal: React.FC<InnerMatchDetailsModalProps> = ({
   match,
   matchNumber,
   roundLabel,

--- a/client/src/components/modals/PlayerSearchResultsModal.tsx
+++ b/client/src/components/modals/PlayerSearchResultsModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Dialog,
   DialogTitle,

--- a/client/src/components/modals/PlayerSelectionModal.tsx
+++ b/client/src/components/modals/PlayerSelectionModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,

--- a/client/src/components/modals/SaveTemplateModal.tsx
+++ b/client/src/components/modals/SaveTemplateModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,

--- a/client/src/components/modals/SoundSettingsModal.tsx
+++ b/client/src/components/modals/SoundSettingsModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Dialog,
   DialogTitle,

--- a/client/src/components/modals/TeamModal.tsx
+++ b/client/src/components/modals/TeamModal.tsx
@@ -94,7 +94,6 @@ export default function TeamModal({ open, team, onClose, onSave }: TeamModalProp
   const [newPlayerName, setNewPlayerName] = useState('');
   const [newPlayerAvatar, setNewPlayerAvatar] = useState<string | undefined>(undefined);
   const [newPlayerElo, setNewPlayerElo] = useState<number | ''>('');
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [error, setError] = useState('');
   const [saving, setSaving] = useState(false);
   const [resolving, setResolving] = useState(false);
@@ -436,6 +435,12 @@ export default function TeamModal({ open, team, onClose, onSave }: TeamModalProp
           </IconButton>
         </DialogTitle>
         <DialogContent sx={{ px: 3, pt: 2, pb: 1 }}>
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }} data-testid="team-modal-error">
+              {error}
+            </Alert>
+          )}
+
           <Box display="flex" flexDirection="column" gap={2}>
             <TextField
               label={t('teamModal.teamNameLabel')}

--- a/client/src/components/player/ELOProgressionChart.tsx
+++ b/client/src/components/player/ELOProgressionChart.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { Box, Typography, Paper } from '@mui/material';
 import { useTheme, alpha } from '@mui/material/styles';
 

--- a/client/src/components/player/PerformanceMetricsChart.tsx
+++ b/client/src/components/player/PerformanceMetricsChart.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { Box, Typography, Paper, Stack, Chip } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 

--- a/client/src/components/player/PlayerAvatar.tsx
+++ b/client/src/components/player/PlayerAvatar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Avatar, Skeleton } from '@mui/material';
 
 interface PlayerAvatarProps {

--- a/client/src/components/team/CurrentMatchDisplayCard.tsx
+++ b/client/src/components/team/CurrentMatchDisplayCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { Card, CardContent, Typography, Button, Box } from '@mui/material';
 import SportsEsportsIcon from '@mui/icons-material/SportsEsports';

--- a/client/src/components/team/MatchInfoCard.tsx
+++ b/client/src/components/team/MatchInfoCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Box, Card, CardContent, Typography, Alert } from '@mui/material';
 import PeopleIcon from '@mui/icons-material/People';
 import { getMapData } from '../../constants/maps';

--- a/client/src/components/team/MatchMapChips.tsx
+++ b/client/src/components/team/MatchMapChips.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Box } from '@mui/material';
 import type { TeamMatchInfo } from '../../types';
 import { MapChipList } from '../match/MapChipList';

--- a/client/src/components/team/MatchPlayerPerformance.tsx
+++ b/client/src/components/team/MatchPlayerPerformance.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Box,
   Paper,

--- a/client/src/components/team/MatchRosterAccordion.tsx
+++ b/client/src/components/team/MatchRosterAccordion.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Accordion,
   AccordionDetails,

--- a/client/src/components/team/MatchScoreboard.tsx
+++ b/client/src/components/team/MatchScoreboard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Stack, Typography, Chip, Paper, Box } from '@mui/material';
 import { CURRENT_MAP_SCORE_LABEL, SERIES_SCORE_LABEL } from '../../utils/matchScoreDisplay';
 

--- a/client/src/components/team/MatchServerPanel.tsx
+++ b/client/src/components/team/MatchServerPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Box, Button, Typography, Alert } from '@mui/material';
 import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';

--- a/client/src/components/team/MatchVetoHistory.tsx
+++ b/client/src/components/team/MatchVetoHistory.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Accordion, AccordionDetails, AccordionSummary, Box, Chip, Stack, Typography } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import type { VetoAction } from '../../types';

--- a/client/src/components/team/PlayerRosterCard.tsx
+++ b/client/src/components/team/PlayerRosterCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Box, Card, CardContent, Typography, Stack, Paper, IconButton, Tooltip } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';

--- a/client/src/components/team/TeamHeader.tsx
+++ b/client/src/components/team/TeamHeader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Box, Card, CardContent, Typography, IconButton, Tooltip } from '@mui/material';
 import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 import VolumeOffIcon from '@mui/icons-material/VolumeOff';

--- a/client/src/components/team/TeamMatchHistory.tsx
+++ b/client/src/components/team/TeamMatchHistory.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
   Box,
   Card,

--- a/client/src/components/team/TeamMatchHistoryModal.tsx
+++ b/client/src/components/team/TeamMatchHistoryModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Dialog,
   DialogTitle,

--- a/client/src/components/team/TeamStatsCard.tsx
+++ b/client/src/components/team/TeamStatsCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Box, Card, CardContent, Typography, Grid, Paper } from '@mui/material';
 import LeaderboardIcon from '@mui/icons-material/Leaderboard';
 import type { TeamStats, TeamStanding } from '../../types';

--- a/client/src/components/tournament/MapPoolStep.tsx
+++ b/client/src/components/tournament/MapPoolStep.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Box,
   Typography,

--- a/client/src/components/tournament/RoundStatusCard.tsx
+++ b/client/src/components/tournament/RoundStatusCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Card,
   CardContent,

--- a/client/src/components/tournament/ShuffleMapsCard.tsx
+++ b/client/src/components/tournament/ShuffleMapsCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Box, Typography, Card, CardContent, Grid } from '@mui/material';
 import MapIcon from '@mui/icons-material/Map';
 import { api } from '../../utils/api';

--- a/client/src/components/tournament/ShufflePlayerRegistration.tsx
+++ b/client/src/components/tournament/ShufflePlayerRegistration.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Box,
   Typography,

--- a/client/src/components/tournament/ShuffleTournamentStats.tsx
+++ b/client/src/components/tournament/ShuffleTournamentStats.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Box, Typography, Card, CardContent, Divider } from '@mui/material';
 import GroupsIcon from '@mui/icons-material/Groups';
 import SportsEsportsIcon from '@mui/icons-material/SportsEsports';

--- a/client/src/components/tournament/SortableMapList.tsx
+++ b/client/src/components/tournament/SortableMapList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   DndContext,
   closestCenter,

--- a/client/src/components/tournament/TeamSelectionStep.tsx
+++ b/client/src/components/tournament/TeamSelectionStep.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Box, Typography, Chip, Alert, Button, Autocomplete, TextField } from '@mui/material';
 import { Warning as WarningIcon, Add as AddIcon } from '@mui/icons-material';
 import { Team } from '../../types';

--- a/client/src/components/tournament/TournamentFormActions.tsx
+++ b/client/src/components/tournament/TournamentFormActions.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Box, Button, Tooltip, CircularProgress } from '@mui/material';
 import { DeleteForever as DeleteForeverIcon, Save as SaveIcon } from '@mui/icons-material';
 import { validateMapCount } from '../../utils/tournamentVerification';

--- a/client/src/components/tournament/TournamentFormatStep.tsx
+++ b/client/src/components/tournament/TournamentFormatStep.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Box,
   Typography,

--- a/client/src/components/tournament/TournamentNameStep.tsx
+++ b/client/src/components/tournament/TournamentNameStep.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Box, TextField } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 

--- a/client/src/components/tournament/TournamentTypeChecklist.tsx
+++ b/client/src/components/tournament/TournamentTypeChecklist.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Card, List, ListItem, ListItemIcon, ListItemText } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';

--- a/client/src/components/tournament/TournamentTypeFormatStep.tsx
+++ b/client/src/components/tournament/TournamentTypeFormatStep.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Box,
   Typography,

--- a/client/src/components/tournament/TournamentWelcomeScreen.tsx
+++ b/client/src/components/tournament/TournamentWelcomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Card,
   CardContent,

--- a/client/src/components/visualizations/BracketsViewerVisualization.tsx
+++ b/client/src/components/visualizations/BracketsViewerVisualization.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Box, useTheme } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import {

--- a/client/src/components/visualizations/SwissView.tsx
+++ b/client/src/components/visualizations/SwissView.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Box,
   Card,

--- a/client/src/contexts/PageHeaderContext.tsx
+++ b/client/src/contexts/PageHeaderContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { createContext, useContext, useState, ReactNode } from 'react';
 
 interface PageHeaderContextType {
   headerActions: ReactNode | null;

--- a/client/src/pages/Bracket.tsx
+++ b/client/src/pages/Bracket.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   Box,
   Typography,

--- a/client/src/pages/ConnectSteam.tsx
+++ b/client/src/pages/ConnectSteam.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Box, Button, Container, Typography, Card, CardContent, Stack } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Box, Stack, Alert } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { OnboardingChecklist } from '../components/dashboard/OnboardingChecklist';

--- a/client/src/pages/ELOTemplates.tsx
+++ b/client/src/pages/ELOTemplates.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { usePageHeader } from '../contexts/PageHeaderContext';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import {

--- a/client/src/pages/Maps.tsx
+++ b/client/src/pages/Maps.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { usePageHeader } from '../contexts/PageHeaderContext';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { Box, Button, CircularProgress, Tabs, Tab } from '@mui/material';

--- a/client/src/pages/Matches.tsx
+++ b/client/src/pages/Matches.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Box, Typography, Grid, LinearProgress, Snackbar, Alert, Stack, Button, Chip } from '@mui/material';
 import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
 import AddIcon from '@mui/icons-material/Add';

--- a/client/src/pages/NotFound.tsx
+++ b/client/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Box, Button, Card, CardContent, Container, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';

--- a/client/src/pages/Players.tsx
+++ b/client/src/pages/Players.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { usePageHeader } from '../contexts/PageHeaderContext';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import {

--- a/client/src/pages/TeamMatch.tsx
+++ b/client/src/pages/TeamMatch.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useParams, Link as RouterLink } from 'react-router-dom';
 import {
   Box,

--- a/client/src/pages/Teams.tsx
+++ b/client/src/pages/Teams.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { usePageHeader } from '../contexts/PageHeaderContext';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { Box, Button, Card, CardContent, Typography, Grid, Chip, CircularProgress } from '@mui/material';

--- a/client/src/pages/Templates.tsx
+++ b/client/src/pages/Templates.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { usePageHeader } from '../contexts/PageHeaderContext';
 import {

--- a/scripts/typecheck-baseline.json
+++ b/scripts/typecheck-baseline.json
@@ -1,4 +1,4 @@
 {
   "api": 54,
-  "client": 289
+  "client": 96
 }


### PR DESCRIPTION
Works through Vikunja #4. The client had 289 type errors that never failed
a build, because Vite strips types without checking them. Two of them were
real user-facing bugs.

## MatchDetailsModal — 125 errors, one line

The component already had the wrapper/inner split that establishes a
non-null `match`. But the inner props were typed
`Required<MatchDetailsModalProps>`, and `Required<T>` strips `?`, not
`| null` — so every one of the ~125 `match.` dereferences in the file was
an error. The inner props now exclude null.

## Swallowed validation errors — real bug

`TeamModal` and `BatchServerModal` both call `setError()` with real
messages — "team name required", "host required", port-range errors — and
**neither ever rendered `error`**. Failed validation showed the user
nothing: click Save, nothing happens.

Someone had noticed the unused variable and silenced it with
`// eslint-disable-next-line @typescript-eslint/no-unused-vars` instead of
fixing it. Both modals now render the standard error `Alert`, matching
`ServerModal` and `MapModal`.

## PlayerRoster teamColor — real bug

`teamColor` was threaded in from both call sites (`'primary'` / `'error'`)
and then never used, so both team panels rendered identically. It now
colours the team name.

## The rest

61 unused `import React` lines left from before the JSX runtime, and two
unused callback params in the vendored brackets-viewer.

## What's left

Ratchet baseline lowered 289 → 96. The remaining errors are mostly TS2339
shape mismatches worth a closer look — e.g. `MatchCard` reads
`match.liveStats` and `config.maxRounds`, neither of which exists on the
types. Those need checking against what the API actually sends, so I left
them for a follow-up rather than silencing them.

Suite: **94/94**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)