### PR TITLE
fix(api): stop one unhandled rejection from killing the server

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -308,6 +308,11 @@ app.get('/health', (_req: Request, res: Response) => {
   res.json({
     status: 'ok',
     timestamp: new Date().toISOString(),
+    // Seconds this process has been running. A drop means the API restarted,
+    // which is the difference between "survived an error" and "crashed and
+    // came back" — indistinguishable from the outside otherwise, since the
+    // container restarts in a couple of seconds.
+    uptime: Math.floor(process.uptime()),
   });
 });
 
@@ -413,6 +418,29 @@ initializeSocket(httpServer);
 
 // Cleanup old event logs (keep last 30 days)
 cleanupOldLogs(30);
+
+// A rejected promise with no catch is fatal in Node by default, so a single
+// stray background task can take the whole tournament server down mid-match.
+// This was not hypothetical: a background settings read rejected with
+// `relation "app_settings" does not exist` and killed the process, after
+// which Caddy served 502 for every request.
+//
+// A rejection is not evidence that the process state is corrupt, so log it
+// loudly and keep serving.
+process.on('unhandledRejection', (reason) => {
+  const err = reason instanceof Error ? reason : new Error(String(reason));
+  log.error(`[FATAL-GUARD] Unhandled promise rejection: ${err.message}`);
+  if (err.stack) log.error(err.stack);
+});
+
+// An uncaught exception is different: it unwound the stack somewhere
+// arbitrary, so continuing risks acting on corrupt state. Log it and let the
+// container restart us.
+process.on('uncaughtException', (err) => {
+  log.error(`[FATAL] Uncaught exception, shutting down: ${err.message}`);
+  if (err.stack) log.error(err.stack);
+  process.exit(1);
+});
 
 // Initialize database and start server
 (async () => {

--- a/tests/api/resilience.spec.ts
+++ b/tests/api/resilience.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import { signInViaRequest, getAuthHeader } from '../helpers/auth';
+
+/**
+ * API resilience
+ *
+ * Node treats an unhandled promise rejection as fatal. The API registered no
+ * `unhandledRejection` handler, so a single stray rejection in a background
+ * task killed the whole process — Caddy then served 502 for every request
+ * until Docker restarted the container.
+ *
+ * This was not theoretical. Resetting the database while requests were in
+ * flight made a settings read reject with `relation "app_settings" does not
+ * exist`, and the process died on the first attempt, every time.
+ *
+ * The assertion below leans on `/health`'s uptime rather than on it merely
+ * answering: the container restarts within a few seconds, so "the API
+ * responds afterwards" would pass even with the bug present.
+ *
+ * @tag api
+ * @tag resilience
+ */
+
+async function uptime(request: import('@playwright/test').APIRequestContext): Promise<number> {
+  const response = await request.get('/health', { timeout: 15000 });
+  expect(response.ok(), '/health should answer').toBe(true);
+  const body = await response.json();
+  expect(typeof body.uptime, '/health should report uptime').toBe('number');
+  return body.uptime as number;
+}
+
+test.describe.serial('API resilience', () => {
+  test(
+    'should survive a rejected background query instead of dying',
+    { tag: ['@api', '@resilience'] },
+    async ({ request }) => {
+      await signInViaRequest(request);
+
+      const before = await uptime(request);
+
+      // Drop the schema out from under a burst of in-flight reads. Each read
+      // that lands mid-reset rejects inside a background path with no catch,
+      // which is precisely what used to be fatal.
+      for (let round = 0; round < 3; round++) {
+        const inFlight = Array.from({ length: 25 }, () =>
+          request
+            .get('/api/settings', { headers: getAuthHeader(), timeout: 20000 })
+            .catch(() => null)
+        );
+        await request.post('/api/test/reset-database', {
+          headers: getAuthHeader(),
+          timeout: 30000,
+        });
+        await Promise.all(inFlight);
+      }
+
+      // Uptime going backwards means the process died and came back.
+      const after = await uptime(request);
+      expect(
+        after,
+        `API restarted during the run (uptime ${before}s -> ${after}s), so a ` +
+          'rejected background query is still fatal'
+      ).toBeGreaterThanOrEqual(before);
+    }
+  );
+});


### PR DESCRIPTION
Vikunja #54.

## The bug

Node treats an unhandled promise rejection as fatal, and the API registers
no `unhandledRejection` handler anywhere — so **a single stray rejection in
any background task kills the whole tournament server**. Caddy then serves
502 for every request until Docker restarts the container.

This is not theoretical. It happened during a test run: a background settings
read rejected with `relation "app_settings" does not exist` and took the
process down mid-suite. In production that is a transient DB blip ending a
live match, taking every in-flight request and socket connection with it.

Reproduced deterministically — dropping the schema under a burst of in-flight
reads killed the API on the first attempt, 3 times out of 3.

## The fix

- `unhandledRejection` logs loudly and keeps serving. A rejection is not
  evidence that process state is corrupt.
- `uncaughtException` still exits. That one unwound the stack somewhere
  arbitrary, so continuing risks acting on corrupt state.

## Why `/health` gained `uptime`

Without it the regression test cannot distinguish "survived" from "crashed
and came back" — the container restarts within a couple of seconds, so
"the API answers afterwards" **would have passed with the bug present**.
Uptime going backwards means the process died.

## Verified both ways

The test fails with the handler removed and passes with it — I rebuilt the
image in both configurations rather than assuming.

Suite: **95/95**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)