### PR TITLE
Stop reporting a match as loaded when the server refused it

### DIFF
--- a/api/src/routes/matches.ts
+++ b/api/src/routes/matches.ts
@@ -7,6 +7,7 @@ import { TournamentResponse } from '../types/tournament.types';
 import { requireAuth } from '../middleware/auth';
 import { log } from '../utils/logger';
 import { db } from '../config/database';
+import { matchConfigFetchTracker } from '../services/matchConfigFetchTracker';
 import type { DbMatchRow, DbTournamentRow } from '../types/database.types';
 import { getBaseUrl, getWebhookBaseUrl } from '../utils/urlHelper';
 import { emitMatchUpdate, emitBracketUpdate } from '../services/socketService';
@@ -392,6 +393,10 @@ router.get('/:slug.json', async (req: Request, res: Response) => {
         error: `Match configuration '${slug}' not found`,
       });
     }
+
+    // The game server fetching this config is the only reliable proof that
+    // MatchZy accepted the load command - see matchConfigFetchTracker.
+    matchConfigFetchTracker.record(slug);
 
     // Manual / non-bracket matches:
     // We treat any match with round = 0 as a manually created match. For these,

--- a/api/src/services/matchConfigFetchTracker.ts
+++ b/api/src/services/matchConfigFetchTracker.ts
@@ -1,0 +1,59 @@
+/**
+ * Records when a game server actually fetched a match's config JSON.
+ *
+ * Loading a match is a two-step handshake: MAT sends `matchzy_loadmatch_url`
+ * over RCON, and MatchZy then fetches that URL. RCON only tells us the command
+ * was delivered - it says nothing about whether the plugin accepted it. MatchZy
+ * refuses for several reasons ("a match is already setup", GOTV disabled, a
+ * malformed config), and those refusals do not share a common wording, so
+ * pattern-matching the RCON reply will always miss cases.
+ *
+ * The fetch is the one unambiguous signal: if the config was never requested,
+ * the plugin did not load the match, whatever the RCON reply said.
+ *
+ * In-memory on purpose. This only has to answer "did the fetch arrive in the
+ * seconds after we sent the load command", so it does not need to survive a
+ * restart, and a restart mid-load would fail the load anyway.
+ */
+
+const lastFetchBySlug = new Map<string, number>();
+
+/** Slugs are bounded in practice, but do not let a long-lived process grow without limit. */
+const MAX_TRACKED_SLUGS = 500;
+
+export const matchConfigFetchTracker = {
+  /** Call when the match config JSON has been served to someone. */
+  record(slug: string): void {
+    if (lastFetchBySlug.size >= MAX_TRACKED_SLUGS && !lastFetchBySlug.has(slug)) {
+      // Drop the oldest entry. Map preserves insertion order.
+      const oldest = lastFetchBySlug.keys().next();
+      if (!oldest.done) lastFetchBySlug.delete(oldest.value);
+    }
+    lastFetchBySlug.set(slug, Date.now());
+  },
+
+  /** Most recent fetch of this slug's config, or null if it has never been fetched. */
+  lastFetchedAt(slug: string): number | null {
+    return lastFetchBySlug.get(slug) ?? null;
+  },
+
+  /**
+   * Wait for the config to be fetched after `since`.
+   *
+   * @returns true if a fetch arrived within the timeout.
+   */
+  async waitForFetch(slug: string, since: number, timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const fetchedAt = lastFetchBySlug.get(slug);
+      if (fetchedAt !== undefined && fetchedAt >= since) return true;
+      if (Date.now() >= deadline) return false;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  },
+
+  /** Test seam. */
+  reset(): void {
+    lastFetchBySlug.clear();
+  },
+};

--- a/api/src/services/matchLoadingService.ts
+++ b/api/src/services/matchLoadingService.ts
@@ -13,6 +13,13 @@ import { matchLiveStatsService } from './matchLiveStatsService';
 import { serverInitializationService } from './serverInitializationService';
 import { settingsService } from './settingsService';
 import { getMatchZyServerConfigCommands } from '../utils/matchzyRconCommands';
+import { matchConfigFetchTracker } from './matchConfigFetchTracker';
+
+/**
+ * How long to wait for MatchZy to fetch the match config after the load command.
+ * Observed locally at well under a second; the headroom is for a busy server.
+ */
+const CONFIG_FETCH_TIMEOUT_MS = 10_000;
 
 export interface MatchLoadOptions {
   skipWebhook?: boolean; // Deprecated: Webhooks are now persistent, this param is ignored
@@ -258,6 +265,7 @@ export async function loadMatchOnServer(
     // Server initialization has already ensured webhook, auth, and core config are set and persisted
     log.success(`✅ Server ${serverId} ready. Loading match ${matchSlug}`);
     log.info(`Sending load command to ${serverId}: matchzy_loadmatch_url "${configUrl}"`);
+    const loadCommandSentAt = Date.now();
     const loadResult = await rconService.sendCommand(
       serverId,
       `matchzy_loadmatch_url "${configUrl}"`
@@ -269,8 +277,12 @@ export async function loadMatchOnServer(
     });
 
     const responseText = (loadResult.response || '').toLowerCase();
-    const pluginReportedFailure = responseText.includes('match load failed');
     const gotvInactive = responseText.includes('gotv[0] not active');
+    // MatchZy has several refusals and they share no common wording. These are
+    // the ones we know; the config-fetch check below is what catches the rest.
+    const alreadySetUp =
+      responseText.includes('cannot load a new match') || responseText.includes('already setup');
+    const pluginReportedFailure = responseText.includes('match load failed');
 
     const handlePluginFailure = (message: string) => {
       log.warn(message, {
@@ -280,9 +292,11 @@ export async function loadMatchOnServer(
       });
     };
 
-    if (pluginReportedFailure || gotvInactive) {
+    if (pluginReportedFailure || gotvInactive || alreadySetUp) {
       const errorMessage = gotvInactive
         ? 'MatchZy refused to load because GOTV is disabled. Enable GOTV (tv_enable 1) and retry.'
+        : alreadySetUp
+        ? 'MatchZy refused the match because the server still has a previous match set up. End or cancel that match on the server, then load this one again.'
         : 'MatchZy plugin reported that it failed to load the match. Check the server console for the detailed error.';
 
       handlePluginFailure(errorMessage);
@@ -294,6 +308,44 @@ export async function loadMatchOnServer(
         demoUploadConfigured: false,
         rconResponses: results,
       };
+    }
+
+    // RCON accepting the command only means it was delivered. MatchZy still has
+    // to fetch the config, and when it refuses it does so without telling RCON
+    // anything we can rely on - which is how a match could be marked "loaded"
+    // while the server sat on the previous map.
+    //
+    // Only require this of servers we know can reach us. A server that has
+    // never sent an event (a placeholder host, or one used for screenshots)
+    // would never fetch, and failing those would be a regression.
+    if (loadResult.success) {
+      const server = await db.queryOneAsync<{ server_can_reach_api_at: number | null }>(
+        'SELECT server_can_reach_api_at FROM servers WHERE id = ?',
+        [serverId]
+      );
+
+      if (server?.server_can_reach_api_at) {
+        const fetched = await matchConfigFetchTracker.waitForFetch(
+          matchSlug,
+          loadCommandSentAt,
+          CONFIG_FETCH_TIMEOUT_MS
+        );
+
+        if (!fetched) {
+          const errorMessage =
+            'MatchZy never fetched the match config, so the match did not load. ' +
+            'The server is still running whatever it had before. Check the server console for the reason it refused.';
+          handlePluginFailure(errorMessage);
+
+          return {
+            success: false,
+            error: errorMessage,
+            webhookConfigured: false,
+            demoUploadConfigured: false,
+            rconResponses: results,
+          };
+        }
+      }
     }
 
     if (loadResult.success) {


### PR DESCRIPTION
Reproduced against a real CS2 server on the LAN (MatchZy Enhanced 1.4.23, CS2 1.41.7.8/14178), not inferred from the code.

## The bug

MAT decided whether a load worked by looking for two strings in the RCON reply — `match load failed` and `gotv[0] not active`. Anything else counted as success.

MatchZy has more refusals than that, and they share no wording. With a match already set up on the server, loading another returns:

```
[MAT] [LoadMatchDataCommand] A match is already setup with id: 1, cannot load a new match!
```

Neither string matches. So MAT logged `Match maptest3 loaded successfully`, set the match to `loaded`, allocated it and pointed players at it — while the server never fetched the config and stayed on the previous map.

That is [the report from 2026-07-04](https://github.com/sivert-io/matchzy-auto-tournament): *"it can happen that the map I selected for the match isn't the one that actually loads on the server. ex: i select Palacio but i am on Dust II"*. Nobody answered it at the time.

Observed directly: match requested `de_inferno`, MAT reported `status: loaded`, server sat on `de_mirage` for 50+ seconds, and MAT's access log contained **zero** requests for `maptest3.json`. Sending the same command by hand after `css_endmatch` fetched the config once and switched the map — so the load path is fine, the success detection was not.

## The fix

Two layers, because enumerating refusal strings is the approach that just failed.

**Recognise the "already set up" refusal** and say so, naming the remedy rather than leaving an admin guessing.

**Verify the handshake actually completed.** Loading is RCON *plus* an HTTP fetch — the plugin has to pull the config URL. If that fetch never arrives, the match did not load, whatever RCON said. `matchConfigFetchTracker` records when `/api/matches/:slug.json` is served, and the loader waits up to 10s for it. This is what catches refusals we have not seen yet.

The fetch check only applies to servers that have reached the API before (`server_can_reach_api_at`). A server that has never sent an event — a placeholder host, or one kept for screenshots — would never fetch, and failing those would be a regression.

## Verification

On the real server, both directions:

| | before | after |
|---|---|---|
| Load onto a server holding a previous match | `success: true`, match marked `loaded`, map unchanged | `success: false`, refusal explained, match not marked loaded |
| Normal load | works | works — config fetched, `loaded`, server switched `de_inferno` → `de_nuke` |

All 46 API tests pass. `tsc -p api`: 54 errors, unchanged baseline.

The fetch-verification path is a safety net for refusals whose wording we don't know. It is verified not to interfere with a successful load, but nothing forces it in CI — the E2E fixtures use servers that cannot fetch, so they take the guarded path by design.

## Found on the way, not fixed here

A newly added server is **never allocatable for manual matches** until something runs the CS2 version check. `allocatable` requires both `cs2BuildId` and `cs2UpdateCheckedAt`, and those are only set by the tournament-start preflight or a hit on `/api/servers/:id/status`. Reproduced: `availableServerCount: 0` with the server showing online and idle and the match stuck on "Waiting for server" with no reason given; one call to the status endpoint flipped it to `allocatable: true` and the match allocated immediately.

That is mAa4a's report from 2026-01-05 ("I have every server on idle... in match settings it shows Waiting for server"). Left out of this PR to keep it focused; the fix wants the version-check logic extracted out of the route first, which is a bigger change.

Related: a match row left in `loaded` state pins its server as busy indefinitely, which matches sanpy's "after every server has been assigned once, they dont get assigned again" — his workaround was restarting compose *and deleting the matches*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)