### PR TITLE
fix(client): close the type gaps where client and API shapes disagree

### DIFF
--- a/client/src/components/dashboard/TournamentInfoCard.tsx
+++ b/client/src/components/dashboard/TournamentInfoCard.tsx
@@ -85,19 +85,6 @@ export default function TournamentInfoCard({ tournament }: TournamentInfoCardPro
               {tournament.format?.toUpperCase() || 'N/A'}
             </Typography>
           </Box>
-          {tournament.description && (
-            <>
-              <Divider />
-              <Box>
-                <Typography variant="body2" color="text.secondary" gutterBottom>
-                  Description
-                </Typography>
-                <Typography variant="body2">
-                  {tournament.description}
-                </Typography>
-              </Box>
-            </>
-          )}
         </Stack>
       </CardContent>
     </Card>

--- a/client/src/components/modals/EloTemplateEditorModal.tsx
+++ b/client/src/components/modals/EloTemplateEditorModal.tsx
@@ -129,7 +129,7 @@ export default function EloTemplateEditorModal({
           maxAdjustment,
           minAdjustment,
         };
-        const response = await api.put<{ success: boolean; template: EloCalculationTemplate }>(
+        const response = await api.put<{ success: boolean; template: EloCalculationTemplate; error?: string }>(
           `/api/elo-templates/${template.id}`,
           input
         );
@@ -149,7 +149,7 @@ export default function EloTemplateEditorModal({
           maxAdjustment,
           minAdjustment,
         };
-        const response = await api.post<{ success: boolean; template: EloCalculationTemplate }>(
+        const response = await api.post<{ success: boolean; template: EloCalculationTemplate; error?: string }>(
           '/api/elo-templates',
           input
         );

--- a/client/src/components/modals/PlayerImportModal.tsx
+++ b/client/src/components/modals/PlayerImportModal.tsx
@@ -77,17 +77,18 @@ export const PlayerImportModal: React.FC<PlayerImportModalProps> = ({
     if (typeof player !== 'object' || player === null) {
       return `Player ${index + 1}: Invalid player object`;
     }
-    if (!player.steamId || typeof player.steamId !== 'string') {
+    // `typeof x === 'object'` narrows to `object`, which has no index
+    // signature, so reading fields off it is a type error. Go through a
+    // record and let the guards below do the actual narrowing.
+    const { steamId, name, initialELO } = player as Record<string, unknown>;
+    if (!steamId || typeof steamId !== 'string') {
       return `Player ${index + 1}: Missing or invalid steamId`;
     }
-    if (!player.name || typeof player.name !== 'string') {
-      return `Player ${index + 1} (${player.steamId}): Missing or invalid name`;
+    if (!name || typeof name !== 'string') {
+      return `Player ${index + 1} (${steamId}): Missing or invalid name`;
     }
-    if (
-      player.initialELO !== undefined &&
-      (typeof player.initialELO !== 'number' || player.initialELO < 0)
-    ) {
-      return `Player "${player.name}": initialELO must be a positive number or omitted`;
+    if (initialELO !== undefined && (typeof initialELO !== 'number' || initialELO < 0)) {
+      return `Player "${name}": initialELO must be a positive number or omitted`;
     }
     return null;
   };

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -1,6 +1,17 @@
 import { createTheme } from '@mui/material/styles';
 import type {} from '@mui/lab/themeAugmentation';
 
+// The palette below adds Material 3 surface levels to `background`. Declare
+// them so components can read `theme.palette.background.surface2` without the
+// compiler rejecting it.
+declare module '@mui/material/styles' {
+  interface TypeBackground {
+    surface1: string;
+    surface2: string;
+    surface3: string;
+  }
+}
+
 // Material Design 3 Purple theme with maximum roundness
 export const theme = createTheme({
   palette: {

--- a/client/src/types/api.types.ts
+++ b/client/src/types/api.types.ts
@@ -43,6 +43,8 @@ export interface Server {
   cs2UpdateRequiredAt?: number | null;
   /** Best-effort: CS2 server build ID parsed from `version` output. */
   cs2BuildId?: number | null;
+  /** Unix timestamp when MAT last ran the Steam UpToDateCheck for this server. */
+  cs2UpdateCheckedAt?: number | null;
   /** Best-effort: `version` output (display-only; may include multiple lines). */
   cs2VersionString?: string | null;
   /** Unix timestamp when version/build was last fetched via RCON. */

--- a/client/src/types/match.types.ts
+++ b/client/src/types/match.types.ts
@@ -2,7 +2,7 @@
  * Match-related types
  */
 
-import type { Team, MatchMapResult } from './team.types';
+import type { Team, MatchMapResult, MatchLiveStats } from './team.types';
 import type { MatchPhase } from './matchPhase.types';
 
 export interface Match {
@@ -33,11 +33,18 @@ export interface Match {
   mapResults?: MatchMapResult[];
   maps?: string[];
   queuePosition?: number | null; // Position in allocation queue (1 = first in queue, null = already allocated)
+  /**
+   * Live scoreboard for an in-progress match, attached by the API from
+   * matchLiveStatsService. Absent once the match is over.
+   */
+  liveStats?: MatchLiveStats | null;
 }
 
 export interface MatchConfigPlayer {
   steamid: string;
   name: string;
+  /** Filled in by the API from the team roster where one is known. */
+  avatar?: string;
 }
 
 export interface MatchConfigTeam {
@@ -83,11 +90,20 @@ export interface MatchConfig {
    * When provided alongside simulation: true, controls how fast the simulated match runs.
    */
   simulation_timescale?: number;
+  /**
+   * Round-limit metadata the config builder writes alongside the cvars, so
+   * consumers do not have to parse `cvars.mp_maxrounds` back out.
+   */
+  maxRounds?: number;
+  overtimeMode?: 'enabled' | 'disabled';
+  overtimeSegments?: number;
 }
 
 export interface PlayerStats {
   name: string;
   steamId: string;
+  /** Filled in by the API from the team roster where one is known. */
+  avatar?: string;
   kills: number;
   deaths: number;
   assists: number;

--- a/client/src/types/matchPhase.types.ts
+++ b/client/src/types/matchPhase.types.ts
@@ -48,7 +48,10 @@ export const getPhaseDisplay = (phase: MatchPhase): { label: string; color: stri
     case 'post_match':
       return { label: 'POST-MATCH', color: 'success' };
     default:
-      return { label: phase.toUpperCase(), color: 'default' };
+      // Unreachable for the declared union — `phase` narrows to `never` here —
+      // but the API could introduce a phase this client does not know yet, so
+      // keep the fallback and stringify rather than assume.
+      return { label: String(phase).toUpperCase(), color: 'default' };
   }
 };
 

--- a/client/src/types/team.types.ts
+++ b/client/src/types/team.types.ts
@@ -78,6 +78,11 @@ export interface TeamMatchInfo {
   mapResults: MatchMapResult[];
   matchFormat: string;
   loadedAt?: number;
+  /**
+   * NOTE: this mirrors `MatchConfig` in match.types.ts rather than reusing it,
+   * and the two have already drifted — `cvars` was missing here while callers
+   * read it. Worth collapsing into the shared type.
+   */
   config?: {
     // Core player / team counts
     players_per_team?: number;
@@ -91,17 +96,21 @@ export interface TeamMatchInfo {
     maxRounds?: number;
     overtimeMode?: 'enabled' | 'disabled';
     overtimeSegments?: number;
+    /** MatchZy convars carried through from the generated match JSON. */
+    cvars?: {
+      [key: string]: string | number;
+    };
     team1?: {
       id?: string;
       name: string;
       tag?: string;
-      players?: Array<{ steamid: string; name: string }>;
+      players?: Array<{ steamid: string; name: string; avatar?: string }>;
     };
     team2?: {
       id?: string;
       name: string;
       tag?: string;
-      players?: Array<{ steamid: string; name: string }>;
+      players?: Array<{ steamid: string; name: string; avatar?: string }>;
     };
   };
   veto?: TeamMatchVetoSummary | null;

--- a/scripts/typecheck-baseline.json
+++ b/scripts/typecheck-baseline.json
@@ -1,4 +1,4 @@
 {
   "api": 54,
-  "client": 96
+  "client": 73
 }


### PR DESCRIPTION
Follow-up to #148, which left these deliberately rather than silencing them.
Every TS2339 in the client, checked against what the API actually sends.

## Types trailing the API

These fields are real and were being read correctly — the types just never
declared them:

| Field | Where it comes from |
|---|---|
| `Match.liveStats` | attached by the API from `matchLiveStatsService` |
| `MatchConfig.maxRounds` / `overtimeMode` / `overtimeSegments` | written by `matchConfigBuilder` as "explicit round-limit metadata" |
| `PlayerStats.avatar`, `MatchConfigPlayer.avatar` | the API enriches match players with avatars from the team roster |
| `Server.cs2UpdateCheckedAt` | set from the Steam UpToDateCheck |

## Dead UI

`TournamentInfoCard` rendered a description block, but the `tournaments`
table has no description column and no endpoint returns one — it could
never appear. (`tournament_templates` and `manual_match_templates` do have
the column, which is presumably where the idea came from.) Removed.

## Type drift with consequences

`TeamMatch.config` in `team.types.ts` duplicates `MatchConfig` rather than
reusing it, and had already fallen behind: callers read `config.cvars`,
which the copy didn't declare. Added the missing fields and left a note
that the two should be collapsed — that felt like its own change.

## Narrowing and declarations

- `typeof x === 'object'` narrows to `object`, which has no index signature
  (`PlayerImportModal`)
- the ELO template response type omitted the `error` field its own failure
  branch already reads
- the M3 surface levels the theme defines needed declaring on `TypeBackground`
- an exhaustive switch's unreachable `default` called `.toUpperCase()` on `never`

Ratchet baseline **96 → 73**. Suite: **96/96**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)