### PR TITLE
fix(servers): stop a save from closing a dialog opened after it

### DIFF
--- a/client/src/pages/Servers.tsx
+++ b/client/src/pages/Servers.tsx
@@ -657,6 +657,16 @@ export default function Servers() {
     setEditingServer(null);
   };
 
+  /**
+   * Runs after a server is created, updated or deleted.
+   *
+   * Note this deliberately does NOT close the modal: ServerModal already calls
+   * onClose() itself, synchronously, right after onSave(). This function is
+   * async and can run for several seconds — auto-configuration posts to each
+   * new server with a 400ms gap, then schedules another reload 1.5s later — so
+   * a close here lands long after the dialog is gone, and shuts whatever the
+   * user has opened in the meantime.
+   */
   const handleSave = async (createdIds?: string[]) => {
     await loadServers({ useCached: false });
     if (createdIds?.length) {
@@ -677,7 +687,6 @@ export default function Servers() {
         closeSnackbar(key);
       }
     }
-    handleCloseModal();
   };
 
   const handleViewCurrentMatch = async (server: Server, event: React.MouseEvent) => {

--- a/tests/ui/servers.spec.ts
+++ b/tests/ui/servers.spec.ts
@@ -88,14 +88,11 @@ test.describe.serial('Server UI', () => {
       // modal. The previous version looked for that button, found nothing, and
       // silently skipped the entire delete stage while still reporting success.
       //
-      // Saving is asynchronous: handleSave runs auto-configuration, schedules a
-      // server reload 1.5s later, and only then calls handleCloseModal(). Reopen
-      // a dialog inside that window and the trailing close tears it down —
-      // Playwright sees the delete button detach mid-click. Wait the timer out.
-      // (Tracked as a real UI bug; a user clicking quickly hits the same thing.)
-      await page.waitForTimeout(2500);
-      await page.waitForLoadState('networkidle');
-
+      // Reopen the dialog immediately, with no wait. Saving kicks off several
+      // seconds of asynchronous work, and this used to end in a stale
+      // handleCloseModal() that tore down whichever dialog was open by then —
+      // Playwright saw the delete button detach mid-click. Clicking straight
+      // away is what a real user does, and is the point of the assertion.
       await serverCard.click();
       await expect(modal).toBeVisible();
 


### PR DESCRIPTION
Vikunja #53 — a bug I hit while fixing something else and worked around in
the test at the time rather than fixing.

## The bug

Saving a server ran `handleCloseModal()` as its last step. But `ServerModal`
already calls `onClose()` itself, synchronously, right after `onSave()` — so
the parent's close was redundant, and it fired *seconds* late.

`handleSave` is async. It reloads servers, then for a newly created server
posts `reset-initialization` to each id with a 400ms gap, then schedules
another reload 1.5s later. Only after all that did it close the modal.

Open another server inside that window and the stale close tears down the
dialog you just opened. Playwright reproduced it deterministically — the
delete button detached mid-click — and a user clicking quickly hits exactly
the same thing.

## The fix

Drop the trailing close. Nothing else depended on it: the batch modal tracks
its own state, which `handleCloseModal` never touched.

## Test

The servers UI test no longer waits out the timer before reopening the
dialog — that wait was covering for this bug, and clicking straight away is
what a real user does. Passes 3/3 without it, and the test drops from 5.2s
to 2.7s.

Suite: **96/96**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)