### PR TITLE
A stale match record no longer pins a server forever

### DIFF
--- a/api/src/services/matchAllocationService.ts
+++ b/api/src/services/matchAllocationService.ts
@@ -138,8 +138,9 @@ export class MatchAllocationService {
       slug: string;
       match_number: number;
       round: number;
+      loaded_at: number | null;
     }>(
-      `SELECT server_id, slug, match_number, round
+      `SELECT server_id, slug, match_number, round, loaded_at
          FROM matches
         WHERE server_id IS NOT NULL
           AND server_id != ''
@@ -149,6 +150,7 @@ export class MatchAllocationService {
       slug: string;
       matchNumber: number;
       round: number;
+      loadedAt: number | null;
     }>();
     for (const row of dbBusyRows) {
       if (row.server_id && !dbBusyByServer.has(row.server_id)) {
@@ -156,6 +158,7 @@ export class MatchAllocationService {
           slug: row.slug,
           matchNumber: row.match_number,
           round: row.round,
+          loadedAt: row.loaded_at ?? null,
         });
       }
     }
@@ -180,6 +183,14 @@ export class MatchAllocationService {
       inGraceWindow: boolean;
       secondsUntilReady: number | null;
       allocatable: boolean;
+      /** Why this server cannot take a match, for operators staring at an idle server. */
+      notAllocatableReason:
+        | 'offline'
+        | 'busy'
+        | 'grace-window'
+        | 'cs2-out-of-date'
+        | 'cs2-unverified'
+        | null;
     }> = [];
 
     let offlineCount = 0;
@@ -203,7 +214,26 @@ export class MatchAllocationService {
       // a match in warmup but the plugin hasn't updated the ConVar yet.
       const pluginSaysIdle = status === ServerStatus.IDLE;
       const dbSaysBusy = dbBusy !== null;
-      const isIdle = pluginSaysIdle && !dbSaysBusy;
+
+      // A freshly loaded match legitimately looks idle for a moment: MatchZy has
+      // not flipped its convar yet. Past that window, a server the plugin calls
+      // idle while our own row still says "loaded" means the row is stale - the
+      // match was abandoned, or the load only appeared to succeed. Holding the
+      // server hostage on that row is what made servers stop being allocated
+      // after their first match, recoverable only by deleting the matches.
+      const dbBusyIsRecent =
+        dbBusy !== null &&
+        (dbBusy.loadedAt === null || now - dbBusy.loadedAt < GRACE_PERIOD_SECONDS);
+      const dbRecordIsStale = dbSaysBusy && pluginSaysIdle && !dbBusyIsRecent;
+
+      if (dbRecordIsStale) {
+        log.warn(
+          `[ALLOCATION] ${server.id} reports idle but match ${dbBusy?.slug} is still marked loaded; ` +
+            `treating the record as stale and allowing allocation`
+        );
+      }
+
+      const isIdle = pluginSaysIdle && (!dbSaysBusy || dbRecordIsStale);
       
       let inGraceWindow = false;
       let secondsUntilReady: number | null = null;
@@ -246,6 +276,15 @@ export class MatchAllocationService {
         availableServerCount += 1;
       }
 
+      let notAllocatableReason: (typeof servers)[number]['notAllocatableReason'] = null;
+      if (!allocatable) {
+        if (!online) notAllocatableReason = 'offline';
+        else if (!isIdle) notAllocatableReason = 'busy';
+        else if (inGraceWindow) notAllocatableReason = 'grace-window';
+        else if (isOutOfDate) notAllocatableReason = 'cs2-out-of-date';
+        else if (!isCs2Verified) notAllocatableReason = 'cs2-unverified';
+      }
+
       servers.push({
         id: server.id,
         name: server.name,
@@ -258,6 +297,7 @@ export class MatchAllocationService {
         inGraceWindow,
         secondsUntilReady,
         allocatable,
+        notAllocatableReason,
       });
     }
 


### PR DESCRIPTION
The second half of the allocation problem from Discord. [#154](https://github.com/sivert-io/matchzy-auto-tournament/pull/154) fixed servers never *becoming* allocatable; this fixes them never becoming allocatable *again*.

## The bug

```ts
const isIdle = pluginSaysIdle && !dbSaysBusy;
```

Any match row left at `loaded` or `live` held its server out of allocation indefinitely, no matter what the server itself reported. A match that was abandoned — or one that only *appeared* to load, which was possible until [#151](https://github.com/sivert-io/matchzy-auto-tournament/pull/151) — took its server down with it, permanently.

That is sanpy's report from 2026-01-05: *"after every server has been assigned once, they dont get assigned again"*. And it explains the shape of his workaround: **"I can fix that with `sudo docker compose restart` — followed by deleting and creating new matches then servers get allocated again."** Restarting alone was never enough, because the rows survive a restart.

The comment a few lines above the bug already described the intended behaviour:

> we no longer block allocatability purely on the DB view. This avoids servers getting "stuck" as busy in the UI after manual restarts when the plugin reports them as idle.

The code never matched it.

## Why not just trust the plugin

Because the comment at the `isIdle` line is also right: a freshly loaded match looks idle for a moment, since MatchZy has not flipped its convar yet. Treating that as free double-books the server.

Both concerns fit if the DB row is trusted **only while it is fresh**. Inside the allocation grace window the row wins. Past it, a server the plugin calls idle while our row still says `loaded` means the row is stale — release the server, and log the mismatch with the match slug so it is visible rather than mysterious.

## Say why, too

Every server in the availability payload now carries `notAllocatableReason`: `offline`, `busy`, `grace-window`, `cs2-out-of-date`, `cs2-unverified`.

An idle-looking server that quietly refuses to take matches, with nothing anywhere explaining it, is the part that actually cost mAa4a and sanpy their evenings — both bugs were invisible from the UI.

## Verification

Against the real CS2 server:

| state | result |
|---|---|
| row loaded 10 min ago, plugin idle | `allocatable: true`, logged: `cs2-real-1 reports idle but match stale1 is still marked loaded; treating the record as stale and allowing allocation` |
| same row loaded 5 s ago | still pinned, `notAllocatableReason: busy` |
| server with no CS2 verification | `notAllocatableReason: cs2-unverified` |

All 47 API tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)