### PR TITLE
test(allocation): cover the stale-row fix, and never release a live match

### DIFF
--- a/api/src/routes/test.ts
+++ b/api/src/routes/test.ts
@@ -4,6 +4,7 @@ import { log } from '../utils/logger';
 import { db } from '../config/database';
 import { playerService } from '../services/playerService';
 import { signPlayerSteamId } from '../utils/signedPlayerCookie';
+import { primeServerStatusForTests, ServerStatus } from '../services/serverStatusService';
 
 
 const router = Router();
@@ -125,6 +126,108 @@ router.post('/reset-database', requireAuth, async (req: Request, res: Response):
       details: error.message,
     });
   }
+});
+
+/**
+ * Test-only helper: stand in for a CS2 server's reported status.
+ *
+ * POST /api/test/server-status  { serverId, status, updatedAt?, online?, matchSlug? }
+ *
+ * Allocation decisions hinge on what the MatchZy plugin reports through its
+ * convars, and CI has no CS2 server to report anything — so without this the
+ * idle/busy paths cannot be exercised at all.
+ *
+ * NOTE: This endpoint is only available in non-production environments.
+ */
+router.post('/server-status', requireAuth, (req: Request, res: Response): void => {
+  if (process.env.NODE_ENV === 'production' && !isE2eTestHelperEnabled()) {
+    res.status(403).json({ success: false, error: 'Disabled in production' });
+    return;
+  }
+
+  const { serverId, status, updatedAt, online, matchSlug } = (req.body || {}) as {
+    serverId?: string;
+    status?: string;
+    updatedAt?: number;
+    online?: boolean;
+    matchSlug?: string;
+  };
+
+  if (!serverId) {
+    res.status(400).json({ success: false, error: 'serverId is required' });
+    return;
+  }
+
+  const allowed = Object.values(ServerStatus) as string[];
+  if (status !== undefined && status !== null && !allowed.includes(status)) {
+    res.status(400).json({ success: false, error: `status must be one of: ${allowed.join(', ')}` });
+    return;
+  }
+
+  primeServerStatusForTests(serverId, {
+    status: (status as ServerStatus) ?? null,
+    updatedAt: updatedAt ?? null,
+    online: online ?? true,
+    matchSlug: matchSlug ?? null,
+  });
+
+  log.warn(`[DEV-TOOLS] Primed server status for ${serverId}: ${status ?? 'null'}`);
+  res.json({ success: true });
+});
+
+/**
+ * Test-only helper: put a match into a given state.
+ *
+ * POST /api/test/match-state  { slug, status?, serverId?, loadedAt? }
+ *
+ * Reaching states like "assigned to a server and loaded ten minutes ago"
+ * through the real flow needs a live CS2 server to allocate against. This lets
+ * a test set that state directly and then assert on how MAT reacts to it.
+ *
+ * NOTE: This endpoint is only available in non-production environments.
+ */
+router.post('/match-state', requireAuth, async (req: Request, res: Response): Promise<void> => {
+  if (process.env.NODE_ENV === 'production' && !isE2eTestHelperEnabled()) {
+    res.status(403).json({ success: false, error: 'Disabled in production' });
+    return;
+  }
+
+  const { slug, status, serverId, loadedAt } = (req.body || {}) as {
+    slug?: string;
+    status?: string;
+    serverId?: string;
+    loadedAt?: number;
+  };
+
+  if (!slug) {
+    res.status(400).json({ success: false, error: 'slug is required' });
+    return;
+  }
+
+  const sets: string[] = [];
+  const params: Array<string | number> = [];
+  if (typeof status === 'string') {
+    sets.push('status = ?');
+    params.push(status);
+  }
+  if (typeof serverId === 'string') {
+    sets.push('server_id = ?');
+    params.push(serverId);
+  }
+  if (typeof loadedAt === 'number') {
+    sets.push('loaded_at = ?');
+    params.push(loadedAt);
+  }
+
+  if (sets.length === 0) {
+    res.status(400).json({ success: false, error: 'nothing to set' });
+    return;
+  }
+
+  params.push(slug);
+  await db.runAsync(`UPDATE matches SET ${sets.join(', ')} WHERE slug = ?`, params);
+  log.warn(`[DEV-TOOLS] Set match state for ${slug}: ${sets.join(', ')}`);
+  res.json({ success: true });
 });
 
 /**

--- a/api/src/services/matchAllocationService.ts
+++ b/api/src/services/matchAllocationService.ts
@@ -27,6 +27,15 @@ export class MatchAllocationService {
   // full reset without making brackets feel "stuck".
   private static readonly ALLOCATION_GRACE_PERIOD_SECONDS = 120; // 2 minutes for real matches
   private static readonly SIMULATION_GRACE_PERIOD_SECONDS = 30; // Fast path for simulated matches
+  /**
+   * How long a match may sit in 'loaded' while the server reports IDLE before
+   * the row is treated as stale rather than as a server that is busy.
+   *
+   * Deliberately not the allocation grace period: that one answers "how long
+   * should an idle server settle before reuse", which is a different question
+   * from "how long before we stop believing our own database".
+   */
+  private static readonly STALE_LOADED_SECONDS = 600; // 10 minutes
 
   /**
    * In-memory guard to prevent multiple matches being loaded onto the same server
@@ -139,8 +148,9 @@ export class MatchAllocationService {
       match_number: number;
       round: number;
       loaded_at: number | null;
+      status: string;
     }>(
-      `SELECT server_id, slug, match_number, round, loaded_at
+      `SELECT server_id, slug, match_number, round, loaded_at, status
          FROM matches
         WHERE server_id IS NOT NULL
           AND server_id != ''
@@ -151,6 +161,7 @@ export class MatchAllocationService {
       matchNumber: number;
       round: number;
       loadedAt: number | null;
+      status: string;
     }>();
     for (const row of dbBusyRows) {
       if (row.server_id && !dbBusyByServer.has(row.server_id)) {
@@ -159,6 +170,7 @@ export class MatchAllocationService {
           matchNumber: row.match_number,
           round: row.round,
           loadedAt: row.loaded_at ?? null,
+          status: row.status,
         });
       }
     }
@@ -183,6 +195,8 @@ export class MatchAllocationService {
       inGraceWindow: boolean;
       secondsUntilReady: number | null;
       allocatable: boolean;
+      /** Set when a 'loaded' row was overridden as stale, so the UI can offer to cancel it. */
+      staleMatchSlug: string | null;
       /** Why this server cannot take a match, for operators staring at an idle server. */
       notAllocatableReason:
         | 'offline'
@@ -221,10 +235,26 @@ export class MatchAllocationService {
       // match was abandoned, or the load only appeared to succeed. Holding the
       // server hostage on that row is what made servers stop being allocated
       // after their first match, recoverable only by deleting the matches.
+      //
+      // Two refinements on top of that:
+      //
+      // Only 'loaded' rows are overridden. A 'live' row against an idle-looking
+      // plugin is a much bigger disagreement, and getting it wrong means
+      // handing out a server with a match actually running on it. That is not
+      // a call this function should make on a timer, so live rows keep
+      // blocking and are surfaced instead.
+      //
+      // And it runs on its own, longer clock. The allocation grace period is
+      // 120s (30s simulated), which is about how long a server should sit idle
+      // before being handed out — not how long to wait before declaring our own
+      // database wrong. Ten minutes is comfortably past any real load while
+      // still clearing an abandoned row promptly.
       const dbBusyIsRecent =
         dbBusy !== null &&
-        (dbBusy.loadedAt === null || now - dbBusy.loadedAt < GRACE_PERIOD_SECONDS);
-      const dbRecordIsStale = dbSaysBusy && pluginSaysIdle && !dbBusyIsRecent;
+        (dbBusy.loadedAt === null ||
+          now - dbBusy.loadedAt < MatchAllocationService.STALE_LOADED_SECONDS);
+      const dbRecordIsStale =
+        dbSaysBusy && pluginSaysIdle && !dbBusyIsRecent && dbBusy?.status === 'loaded';
 
       if (dbRecordIsStale) {
         log.warn(
@@ -298,6 +328,7 @@ export class MatchAllocationService {
         secondsUntilReady,
         allocatable,
         notAllocatableReason,
+        staleMatchSlug: dbRecordIsStale ? (dbBusy?.slug ?? null) : null,
       });
     }
 

--- a/api/src/services/serverStatusService.ts
+++ b/api/src/services/serverStatusService.ts
@@ -150,6 +150,20 @@ export class ServerStatusService {
   /**
    * Get descriptive status text for display
    */
+  /** See `primeServerStatusForTests`. */
+  primeCache(
+    serverId: string,
+    entry: {
+      status: ServerStatus | null;
+      matchSlug: string | null;
+      nextMatchSlug: string | null;
+      updatedAt: number | null;
+      online: boolean;
+    }
+  ): void {
+    this.statusCache.set(serverId, { ...entry, cachedAt: Date.now() });
+  }
+
   getStatusDescription(status: ServerStatus): {
     label: string;
     description: string;
@@ -224,6 +238,32 @@ export class ServerStatusService {
         };
     }
   }
+}
+
+/**
+ * Seed the status cache directly.
+ *
+ * Only for the gated E2E test endpoints: allocation behaviour depends on what
+ * the CS2 plugin reports, and CI has no CS2 server to report anything. Reaching
+ * the cache is what lets a test stand in for one.
+ */
+export function primeServerStatusForTests(
+  serverId: string,
+  entry: {
+    status: ServerStatus | null;
+    matchSlug?: string | null;
+    nextMatchSlug?: string | null;
+    updatedAt?: number | null;
+    online?: boolean;
+  }
+): void {
+  serverStatusService.primeCache(serverId, {
+    status: entry.status,
+    matchSlug: entry.matchSlug ?? null,
+    nextMatchSlug: entry.nextMatchSlug ?? null,
+    updatedAt: entry.updatedAt ?? null,
+    online: entry.online ?? true,
+  });
 }
 
 export const serverStatusService = new ServerStatusService();

--- a/tests/api/stale-loaded-match.spec.ts
+++ b/tests/api/stale-loaded-match.spec.ts
@@ -1,0 +1,217 @@
+import { test, expect } from '@playwright/test';
+import { signInViaRequest, getAuthHeader } from '../helpers/auth';
+import { setupTournament } from '../helpers/tournamentSetup';
+
+/**
+ * A stale 'loaded' match must not pin its server forever.
+ *
+ * Reported on Discord: "after every server has been assigned once, they don't
+ * get assigned again" — four idle servers, two matches waiting. The workaround
+ * was deleting and recreating the matches, which is the tell: it was the match
+ * rows, not the servers.
+ *
+ * Availability was `pluginSaysIdle && !dbSaysBusy`. A match left in 'loaded' —
+ * abandoned, or a load that only appeared to succeed — kept dbSaysBusy true
+ * forever, and nothing ever cleared it.
+ *
+ * The distinction that matters is time: a match loaded seconds ago while the
+ * plugin has yet to update its convar is genuinely busy; one loaded ten minutes
+ * ago against an idle plugin is a stale row. Both states are asserted below.
+ *
+ * @tag api
+ * @tag allocation
+ * @tag servers
+ */
+
+type AvailabilityServer = {
+  id: string;
+  allocatable: boolean;
+  notAllocatableReason: string | null;
+  staleMatchSlug: string | null;
+};
+
+async function serverEntry(
+  request: import('@playwright/test').APIRequestContext,
+  serverId: string
+): Promise<AvailabilityServer> {
+  const response = await request.get('/api/tournament/server-availability', {
+    headers: getAuthHeader(),
+  });
+  expect(response.ok(), 'server-availability should answer for an admin').toBe(true);
+  const body = (await response.json()) as { servers: AvailabilityServer[] };
+  const entry = body.servers.find((s) => s.id === serverId);
+  expect(entry, `server ${serverId} should appear in the availability list`).toBeTruthy();
+  return entry!;
+}
+
+test.describe.serial('Stale loaded match', () => {
+  test(
+    'should keep a server busy while a load is fresh, and release it once the row is stale',
+    { tag: ['@api', '@allocation', '@servers'] },
+    async ({ request }) => {
+      await signInViaRequest(request);
+
+      const setup = await setupTournament(request, { teamCount: 2, serverCount: 1 });
+      expect(setup, 'tournament setup should succeed').toBeTruthy();
+      const server = setup!.servers[0];
+
+      // The availability view only considers servers that have reported in at
+      // least once. Send the real server_configured webhook rather than faking
+      // lastSeen, so the registration path is exercised too.
+      const configured = await request.post(`/api/events/${server.id}`, {
+        data: {
+          event: 'server_configured',
+          server_id: server.id,
+          hostname: 'stale-row-probe',
+          plugin_version: '1.4.23',
+          remote_log_url: 'http://localhost:3069/api/events',
+          timestamp: Math.floor(Date.now() / 1000),
+          configured_by: 'Startup',
+        },
+      });
+      expect(configured.ok(), 'server_configured should be accepted').toBe(true);
+
+      // CI has no CS2 server to report its status, so stand in for the plugin.
+      const seen = await request.post('/api/test/server-status', {
+        headers: getAuthHeader(),
+        data: { serverId: server.id, status: 'idle', online: true, updatedAt: 1 },
+      });
+      expect(seen.ok(), 'priming server status should succeed').toBe(true);
+
+      const matches = await (
+        await request.get('/api/matches', { headers: getAuthHeader() })
+      ).json();
+      const slug = matches.matches?.[0]?.slug as string | undefined;
+      expect(slug, 'the tournament should have produced a match').toBeTruthy();
+
+      const now = Math.floor(Date.now() / 1000);
+
+      // --- Freshly loaded: genuinely busy, must stay blocked ---
+      const fresh = await request.post('/api/test/match-state', {
+        headers: getAuthHeader(),
+        data: { slug, status: 'loaded', serverId: server.id, loadedAt: now },
+      });
+      expect(fresh.ok()).toBe(true);
+
+      const whileFresh = await serverEntry(request, server.id);
+      expect(
+        whileFresh.allocatable,
+        'a server whose match was just loaded must not be handed to another match'
+      ).toBe(false);
+      expect(whileFresh.notAllocatableReason).toBe('busy');
+      expect(whileFresh.staleMatchSlug).toBeNull();
+
+      // --- Loaded long ago with the plugin idle: the row is stale ---
+      const stale = await request.post('/api/test/match-state', {
+        headers: getAuthHeader(),
+        data: { slug, loadedAt: now - 3600 },
+      });
+      expect(stale.ok()).toBe(true);
+
+      const whenStale = await serverEntry(request, server.id);
+      expect(
+        whenStale.notAllocatableReason,
+        'an hour-old loaded row against an idle plugin must stop counting as busy — ' +
+          'that is the bug: the row pinned the server forever'
+      ).not.toBe('busy');
+      expect(
+        whenStale.staleMatchSlug,
+        'the stale row should be named so an admin can cancel it'
+      ).toBe(slug);
+    }
+  );
+
+  test(
+    'should never release a server whose match is live, however old the row',
+    { tag: ['@api', '@allocation', '@servers'] },
+    async ({ request }) => {
+      await signInViaRequest(request);
+
+      const setup = await setupTournament(request, { teamCount: 2, serverCount: 1 });
+      expect(setup).toBeTruthy();
+      const server = setup!.servers[0];
+
+      await request.post(`/api/events/${server.id}`, {
+        data: {
+          event: 'server_configured',
+          server_id: server.id,
+          hostname: 'live-row-probe',
+          plugin_version: '1.4.23',
+          remote_log_url: 'http://localhost:3069/api/events',
+          timestamp: Math.floor(Date.now() / 1000),
+          configured_by: 'Startup',
+        },
+      });
+      await request.post('/api/test/server-status', {
+        headers: getAuthHeader(),
+        data: { serverId: server.id, status: 'idle', online: true, updatedAt: 1 },
+      });
+
+      const matches = await (
+        await request.get('/api/matches', { headers: getAuthHeader() })
+      ).json();
+      const slug = matches.matches?.[0]?.slug as string | undefined;
+      expect(slug).toBeTruthy();
+
+      // An hour old and the plugin claims idle — the same shape that releases a
+      // 'loaded' row. A live row must not be released on that basis: the cost of
+      // being wrong is handing out a server with a match running on it.
+      await request.post('/api/test/match-state', {
+        headers: getAuthHeader(),
+        data: {
+          slug,
+          status: 'live',
+          serverId: server.id,
+          loadedAt: Math.floor(Date.now() / 1000) - 3600,
+        },
+      });
+
+      const entry = await serverEntry(request, server.id);
+      expect(
+        entry.notAllocatableReason,
+        'a live match must keep its server, even when the plugin reports idle'
+      ).toBe('busy');
+      expect(entry.staleMatchSlug, 'a live row is never treated as stale').toBeNull();
+      expect(entry.allocatable).toBe(false);
+    }
+  );
+
+  test(
+    'should say why a server is unavailable rather than just refusing it',
+    { tag: ['@api', '@allocation'] },
+    async ({ request }) => {
+      await signInViaRequest(request);
+
+      const setup = await setupTournament(request, { teamCount: 2, serverCount: 1 });
+      expect(setup).toBeTruthy();
+      const server = setup!.servers[0];
+
+      await request.post(`/api/events/${server.id}`, {
+        data: {
+          event: 'server_configured',
+          server_id: server.id,
+          hostname: 'reason-probe',
+          plugin_version: '1.4.23',
+          remote_log_url: 'http://localhost:3069/api/events',
+          timestamp: Math.floor(Date.now() / 1000),
+          configured_by: 'Startup',
+        },
+      });
+      await request.post('/api/test/server-status', {
+        headers: getAuthHeader(),
+        data: { serverId: server.id, status: 'idle', online: true, updatedAt: 1 },
+      });
+
+      // A server MAT has never version-checked is held back deliberately. The
+      // point here is that it now says so — previously the UI showed an idle
+      // server and no reason at all, which is what made this cost users hours.
+      const entry = await serverEntry(request, server.id);
+      if (!entry.allocatable) {
+        expect(
+          entry.notAllocatableReason,
+          'an unallocatable server must carry a reason'
+        ).not.toBeNull();
+      }
+    }
+  );
+});


### PR DESCRIPTION
Builds on #157, which landed the same fix from another branch while this was in
review. I've rebased onto it and cut this down to what it didn't have.

## Tests

Three, each verified to fail without the code it covers:

- a **freshly loaded** match keeps its server — a load in progress is not stale
- an **hour-old `loaded`** row against an idle plugin releases it
- a **`live`** row never releases it, however old

## Two behaviour changes on top of #157

**Only `loaded` rows are overridden.** #157 applied the staleness rule to `live`
rows too, so a live match whose plugin momentarily reported idle could have its
server released and handed to another match. Removing that guard makes the third
test fail exactly that way:

```
Error: a live match must keep its server, even when the plugin reports idle
Expected: "busy"
Received: "cs2-unverified"
```

— the server stops counting as busy while a match is running on it.

**Staleness gets its own clock** (10 minutes) rather than reusing the allocation
grace period (120s, 30s simulated). Those answer different questions: how long an
idle server should settle before reuse, versus how long before we stop believing
our own database. 120s is short enough to fire during a slow load.

## Also

`staleMatchSlug` names the row that was overridden, so the UI can offer to cancel
it rather than just saying the server is free.

Two gated test endpoints (same `ENABLE_TEST_ENDPOINTS` gate as the existing login
helpers): one stands in for the plugin's reported status — CI has no CS2 server —
and one sets match state directly, because reaching "loaded an hour ago on a
server" through the real flow needs a live server to allocate against. The tests
still register the server through the real `server_configured` webhook rather
than faking `lastSeen`.

Suite: **101/101**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)