### PR TITLE
A BO3/BO5 records every map, not just the last one

### DIFF
--- a/api/src/services/matchEventHandler.ts
+++ b/api/src/services/matchEventHandler.ts
@@ -1126,8 +1126,12 @@ async function persistPlayerMatchStats(options: {
   // These include cumulative per-player damage and rounds_played, which we use
   // to derive ADR. This avoids needing a separate "player_stats" event from
   // the plugin.
-  const liveStats = matchLiveStatsService.getStats(matchSlug);
-  if (liveStats?.playerStats) {
+  // Series totals, not just the map that happened to finish last. `round_end`
+  // reports stats cumulative within the current map, so reading `playerStats`
+  // directly recorded only the final map of a BO3/BO5 - which is what made a
+  // player's profile show the last map's KDA for a whole series.
+  const seriesPlayerStats = matchLiveStatsService.getSeriesPlayerStats(matchSlug);
+  if (seriesPlayerStats) {
     const toMap = (lines: PlayerStatLine[]): Record<string, Record<string, unknown>> => {
       const map: Record<string, Record<string, unknown>> = {};
       for (const line of lines) {
@@ -1148,8 +1152,8 @@ async function persistPlayerMatchStats(options: {
       return map;
     };
 
-    team1PlayerStats = toMap(liveStats.playerStats.team1);
-    team2PlayerStats = toMap(liveStats.playerStats.team2);
+    team1PlayerStats = toMap(seriesPlayerStats.team1);
+    team2PlayerStats = toMap(seriesPlayerStats.team2);
   } else {
     // Fallback for older/alternate setups: look for a dedicated "player_stats"
     // match event if present and parse its per-player dictionaries.

--- a/api/src/services/matchLiveStatsService.ts
+++ b/api/src/services/matchLiveStatsService.ts
@@ -35,7 +35,81 @@ export interface MatchLiveStats {
   team2SeriesScore: number;
   mapName?: string | null;
   totalMaps: number;
+  /** Stats for the map currently being played. */
   playerStats?: MatchPlayerStatsSnapshot | null;
+  /**
+   * Per-map snapshots, keyed by map number.
+   *
+   * `round_end` carries stats cumulative *within the current map*, so each new
+   * map overwrites `playerStats`. Keeping the finished maps here is what lets a
+   * BO3/BO5 be totalled at series end instead of recording only the last map.
+   */
+  playerStatsByMap?: Record<number, MatchPlayerStatsSnapshot> | null;
+}
+
+/** Sum one player's line across maps. Rates are recomputed, not added. */
+function mergeStatLines(lines: PlayerStatLine[]): PlayerStatLine {
+  const total: PlayerStatLine = {
+    steamId: lines[0].steamId,
+    name: lines[lines.length - 1].name || lines[0].name,
+    kills: 0,
+    deaths: 0,
+    assists: 0,
+    flashAssists: 0,
+    headshotKills: 0,
+    damage: 0,
+    utilityDamage: 0,
+    kast: 0,
+    mvps: 0,
+    score: 0,
+    roundsPlayed: 0,
+  };
+
+  let kastRoundsWeight = 0;
+  for (const line of lines) {
+    total.kills += line.kills;
+    total.deaths += line.deaths;
+    total.assists += line.assists;
+    total.flashAssists += line.flashAssists;
+    total.headshotKills += line.headshotKills;
+    total.damage += line.damage;
+    total.utilityDamage += line.utilityDamage;
+    total.mvps += line.mvps;
+    total.score += line.score;
+    total.roundsPlayed += line.roundsPlayed;
+    // KAST is a percentage, so it is averaged over the rounds it describes.
+    kastRoundsWeight += line.kast * line.roundsPlayed;
+  }
+
+  total.kast = total.roundsPlayed > 0 ? kastRoundsWeight / total.roundsPlayed : 0;
+  return total;
+}
+
+/**
+ * Total each player across every map recorded for the series.
+ *
+ * Falls back to the current map when no per-map history exists, which covers
+ * BO1 and any match that was already in progress before this was recorded.
+ */
+export function sumPlayerStatsAcrossMaps(
+  stats: Pick<MatchLiveStats, 'playerStats' | 'playerStatsByMap'>
+): MatchPlayerStatsSnapshot | null {
+  const perMap = Object.values(stats.playerStatsByMap ?? {});
+  if (perMap.length === 0) return stats.playerStats ?? null;
+
+  const sumSide = (side: 'team1' | 'team2'): PlayerStatLine[] => {
+    const bySteamId = new Map<string, PlayerStatLine[]>();
+    for (const snapshot of perMap) {
+      for (const line of snapshot[side]) {
+        const existing = bySteamId.get(line.steamId);
+        if (existing) existing.push(line);
+        else bySteamId.set(line.steamId, [line]);
+      }
+    }
+    return [...bySteamId.values()].map(mergeStatLines);
+  };
+
+  return { team1: sumSide('team1'), team2: sumSide('team2') };
 }
 
 class MatchLiveStatsService {
@@ -59,6 +133,7 @@ class MatchLiveStatsService {
       mapName: null,
       totalMaps: 1,
       playerStats: null,
+      playerStatsByMap: null,
     };
     this.stats.set(matchSlug, entry);
     return entry;
@@ -72,8 +147,26 @@ class MatchLiveStatsService {
       matchSlug,
       lastEventAt: Date.now(),
     };
+
+    // File the incoming snapshot under the map it belongs to, so finished maps
+    // survive the next map overwriting `playerStats`.
+    if (updates.playerStats && !updates.playerStatsByMap) {
+      const mapNumber = updates.mapNumber ?? current.mapNumber ?? 0;
+      next.playerStatsByMap = {
+        ...(current.playerStatsByMap ?? {}),
+        [mapNumber]: updates.playerStats,
+      };
+    }
+
     this.stats.set(matchSlug, next);
     return next;
+  }
+
+  /** Series totals for a match, summed across every map played. */
+  getSeriesPlayerStats(matchSlug: string): MatchPlayerStatsSnapshot | null {
+    const current = this.stats.get(matchSlug);
+    if (!current) return null;
+    return sumPlayerStatsAcrossMaps(current);
   }
 
   clear(matchSlug: string): void {

--- a/tests/api/series-stats.spec.ts
+++ b/tests/api/series-stats.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from '@playwright/test';
+import { ensureSignedIn, signInViaRequest } from '../helpers/auth';
+import { setupTournament } from '../helpers/tournamentSetup';
+import { createAndStartTournament } from '../helpers/tournaments';
+import { findMatchByTeams } from '../helpers/matches';
+import type { Team } from '../helpers/teams';
+
+/**
+ * Series stats aggregation
+ *
+ * `round_end` reports per-player stats cumulative *within the current map*, so
+ * each new map's events overwrite the previous map's numbers. Recording the
+ * final snapshot therefore captured only the last map of a BO3/BO5, which is
+ * what a user hit on Discord (2026-05-10): "the KDA on your profile is taken
+ * from last map of bo3 or bo5".
+ *
+ * @tag api
+ * @tag stats
+ */
+
+const MAPS = ['de_mirage', 'de_inferno', 'de_ancient', 'de_anubis', 'de_dust2', 'de_vertigo', 'de_nuke'];
+
+interface MapStats {
+  kills: number;
+  deaths: number;
+  assists: number;
+  damage: number;
+  rounds: number;
+}
+
+function roundEndPayload(
+  matchSlug: string,
+  mapNumber: number,
+  team1: Team,
+  team2: Team,
+  statsFor: (steamId: string) => MapStats
+) {
+  const side = (team: Team) => ({
+    players: team.players.map((p) => {
+      const s = statsFor(p.steamId);
+      return {
+        steamid: p.steamId,
+        name: p.name,
+        stats: {
+          kills: s.kills,
+          deaths: s.deaths,
+          assists: s.assists,
+          damage: s.damage,
+          rounds_played: s.rounds,
+          kast: 70,
+        },
+      };
+    }),
+  });
+
+  return {
+    event: 'round_end',
+    matchid: matchSlug,
+    map_number: mapNumber,
+    round_number: 12,
+    winner: 'team1',
+    team1_score: 13,
+    team2_score: 5,
+    team1: side(team1),
+    team2: side(team2),
+  };
+}
+
+test.describe.serial('Series stats', () => {
+  let team1: Team;
+  let team2: Team;
+
+  test.beforeEach(async ({ page, request }) => {
+    await ensureSignedIn(page);
+    await signInViaRequest(request);
+
+    const setup = await setupTournament(request, {
+      type: 'single_elimination',
+      format: 'bo3',
+      maps: MAPS,
+      teamCount: 2,
+      serverCount: 1,
+      prefix: 'series-stats',
+    });
+    expect(setup).toBeTruthy();
+    if (!setup) return;
+    [team1, team2] = [setup.teams[0], setup.teams[1]];
+  });
+
+  test('a BO3 records the sum of every map, not just the last one', {
+    tag: ['@api', '@stats', '@regression'],
+  }, async ({ request }) => {
+    const tournament = await createAndStartTournament(request, {
+      name: `Series Stats ${Date.now()}`,
+      type: 'single_elimination',
+      format: 'bo3',
+      maps: MAPS,
+      teamIds: [team1.id, team2.id],
+    });
+    expect(tournament).toBeTruthy();
+
+    const match = await findMatchByTeams(request, team1.id, team2.id);
+    expect(match?.slug).toBeTruthy();
+    const slug = match!.slug;
+
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-MatchZy-Token': process.env.SERVER_TOKEN ?? 'server123',
+    };
+
+    // Map 1, then map 2 with smaller numbers. If only the last map is kept, the
+    // totals below come out as map 2 alone.
+    const map1: MapStats = { kills: 20, deaths: 10, assists: 4, damage: 2000, rounds: 20 };
+    const map2: MapStats = { kills: 6, deaths: 8, assists: 2, damage: 800, rounds: 10 };
+
+    for (const [mapNumber, stats] of [
+      [1, map1],
+      [2, map2],
+    ] as const) {
+      const res = await request.post(`/api/events/${slug}`, {
+        headers,
+        data: roundEndPayload(slug, mapNumber, team1, team2, () => stats),
+      });
+      expect(res.ok(), `round_end for map ${mapNumber} should be accepted`).toBe(true);
+    }
+
+    const seriesEnd = await request.post(`/api/events/${slug}`, {
+      headers,
+      data: {
+        event: 'series_end',
+        matchid: slug,
+        team1_series_score: 2,
+        team2_series_score: 0,
+        winner: 'team1',
+        num_maps: 3,
+        time_until_restore: 0,
+        team1_name: team1.name,
+        team2_name: team2.name,
+      },
+    });
+    expect(seriesEnd.ok()).toBe(true);
+
+    const steamId = team1.players[0].steamId;
+
+    await expect
+      .poll(
+        async () => {
+          const res = await request.get(`/api/players/${steamId}/summary`);
+          if (!res.ok()) return null;
+          const body = await res.json();
+          const rows = body.matches ?? body.data?.matches ?? [];
+          const row = rows.find((m: { match_slug?: string; slug?: string }) =>
+            (m.match_slug ?? m.slug) === slug
+          );
+          return row?.kills ?? null;
+        },
+        { message: 'stats for the series to be recorded', timeout: 20000, intervals: [500, 1000] }
+      )
+      .not.toBeNull();
+
+    const summary = await (await request.get(`/api/players/${steamId}/summary`)).json();
+    const rows = summary.matches ?? summary.data?.matches ?? [];
+    const row = rows.find((m: { match_slug?: string; slug?: string }) =>
+      (m.match_slug ?? m.slug) === slug
+    );
+
+    expect(row, 'the series should have a stats row').toBeTruthy();
+    // Sum of both maps. Before the fix this was map 2 alone (6/8/2).
+    expect(row.kills).toBe(map1.kills + map2.kills);
+    expect(row.deaths).toBe(map1.deaths + map2.deaths);
+    expect(row.assists).toBe(map1.assists + map2.assists);
+    expect(row.total_damage).toBe(map1.damage + map2.damage);
+  });
+});


### PR DESCRIPTION
`round_end` carries per-player stats cumulative **within the current map**, and the handler assigned that snapshot straight onto `playerStats`. Each new map overwrote the previous one, so the snapshot read at series end described only the final map — and those are the numbers written to `player_match_stats`, which is what a player's profile shows.

From Discord, 2026-05-10:

> when you do not play bo1, the KDA on your profile is taken from last map of bo3 or bo5. Would be nice that every game from boX is entered there.

## The fix

`MatchLiveStats` now keeps `playerStatsByMap` alongside the current map's snapshot, and `getSeriesPlayerStats` totals across every map recorded.

Aggregation isn't just addition:

- counting stats (kills, deaths, assists, damage, utility damage, MVPs, score, rounds) sum
- **KAST** is a percentage, so it is averaged weighted by rounds rather than added
- **ADR** is recomputed downstream from summed damage and summed rounds

With no per-map history — a BO1, or a match already in flight before this ships — it falls back to the current snapshot, so nothing regresses.

Keeping the per-map snapshots also leaves the door open for the per-map scoreboard the same user asked for (*"make the 'Mirage 13-2' clickable and it displays scoreboard for that map only"*) without another round of plumbing.

## Verification

The test drives two maps of a BO3 through `/api/events` with deliberately different numbers, then a `series_end`, and asserts the recorded row is the sum:

| | map 1 | map 2 | expected |
|---|---|---|---|
| kills | 20 | 6 | **26** |
| deaths | 10 | 8 | **18** |
| damage | 2000 | 800 | **2800** |

Reverted against main, it fails with `Expected: 26, Received: 6` — map 2 alone, exactly the reported symptom.

All 50 API tests pass. `tsc -p api`: 45, unchanged baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)