### PR TITLE
fix(admin): End Match now ends the match, not just the round

### DIFF
--- a/api/src/routes/matches.ts
+++ b/api/src/routes/matches.ts
@@ -1508,27 +1508,10 @@ router.post('/:slug/force-cancel', requireAuth, async (req: Request, res: Respon
       }
     }
 
-    // Mark match as cancelled in database (use seconds, not milliseconds)
-    await db.updateAsync(
-      'matches',
-      { status: 'cancelled', completed_at: Math.floor(Date.now() / 1000) },
-      'slug = ?',
-      [slug]
-    );
-
-    log.info(`Match ${slug} force-cancelled`);
-
-    // Free up the server if it was assigned
-    if (serverId) {
-      serverAllocationTracker.markIdle(serverId);
-      log.info(`Server ${serverId} freed by force-cancel, triggering immediate allocation`);
-      setImmediate(() => {
-        void matchAllocationService.tryImmediateAllocation();
-      });
-    }
-
-    // Emit match update
-    emitMatchUpdate({ slug, status: 'cancelled' });
+    // Same settle-up the End Match control performs; shared so the two paths
+    // cannot drift apart.
+    const { settleEndedMatch } = await import('../services/matchTerminationService');
+    await settleEndedMatch(match, 'force-cancel');
 
     return res.json({
       success: true,

--- a/api/src/routes/rcon.ts
+++ b/api/src/routes/rcon.ts
@@ -6,6 +6,10 @@ import { log } from '../utils/logger';
 import { getWebhookBaseUrl } from '../utils/urlHelper';
 import { getMatchZyWebhookCommands } from '../utils/matchzyRconCommands';
 import { getLastServerTestEvent } from '../services/serverConnectivityService';
+import {
+  findActiveMatchForServer,
+  settleEndedMatch,
+} from '../services/matchTerminationService';
 
 const router = Router();
 
@@ -707,8 +711,26 @@ router.post('/end-match', async (req: Request, res: Response) => {
       });
     }
 
-    const result = await rconService.sendCommand(serverId, 'css_restart');
+    // css_restart *restarts* the match; css_endmatch ends it and tells players
+    // an admin did so. Both reset the server, but only one matches the button.
+    const result = await rconService.sendCommand(serverId, 'css_endmatch');
     const statusCode = result.success ? 200 : 400;
+
+    // Ending the match on the server is only half of it. MatchZy emits no event
+    // when a match is force-ended, so unless MAT settles its own record here the
+    // row stays 'live' and the Matches tab keeps showing LIVE — which is exactly
+    // what was reported. Force Cancel already did this; End Match never did.
+    if (result.success) {
+      const match = await findActiveMatchForServer(serverId);
+      if (match) {
+        await settleEndedMatch(match, 'end match');
+      } else {
+        log.warn(
+          `[RCON] End match sent to ${serverId} but no loaded/live match was found for it; ` +
+            'nothing to settle'
+        );
+      }
+    }
 
     return res.status(statusCode).json(result);
   } catch (error) {

--- a/api/src/services/matchTerminationService.ts
+++ b/api/src/services/matchTerminationService.ts
@@ -1,0 +1,61 @@
+import { db } from '../config/database';
+import { log } from '../utils/logger';
+import { emitMatchUpdate } from './socketService';
+import { serverAllocationTracker } from './serverAllocationTracker';
+import { matchAllocationService } from './matchAllocationService';
+import type { DbMatchRow } from '../types/database.types';
+
+/**
+ * Settle MAT's own record after a match has been ended on the game server.
+ *
+ * Ending a match is two separate things: telling the CS2 server to stop, and
+ * recording that it stopped. MatchZy's end command emits no event, so nothing
+ * tells MAT about it — the row has to be settled here or it stays 'live'
+ * forever. That is exactly what "End Match" did: it sent the RCON command and
+ * left the Matches tab showing LIVE indefinitely.
+ *
+ * Shared by the admin End Match control and by force-cancel so the two cannot
+ * drift apart.
+ */
+export async function settleEndedMatch(
+  match: DbMatchRow,
+  reason: string
+): Promise<void> {
+  await db.updateAsync(
+    'matches',
+    { status: 'cancelled', completed_at: Math.floor(Date.now() / 1000) },
+    'slug = ?',
+    [match.slug]
+  );
+
+  log.info(`Match ${match.slug} marked cancelled (${reason})`);
+
+  // A match that is over must not keep its server out of the pool.
+  if (match.server_id) {
+    serverAllocationTracker.markIdle(match.server_id);
+    log.info(`Server ${match.server_id} freed by ${reason}, triggering immediate allocation`);
+    setImmediate(() => {
+      void matchAllocationService.tryImmediateAllocation();
+    });
+  }
+
+  emitMatchUpdate({ slug: match.slug, status: 'cancelled' });
+}
+
+/**
+ * Find the match a server is currently running, if any.
+ *
+ * The admin controls act on a server, not a match, so the row has to be looked
+ * up from the server id.
+ */
+export async function findActiveMatchForServer(serverId: string): Promise<DbMatchRow | null> {
+  const row = await db.queryOneAsync<DbMatchRow>(
+    `SELECT * FROM matches
+      WHERE server_id = ?
+        AND status IN ('loaded', 'live')
+      ORDER BY id DESC
+      LIMIT 1`,
+    [serverId]
+  );
+  return row ?? null;
+}

--- a/tests/api/end-match.spec.ts
+++ b/tests/api/end-match.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+import { signInViaRequest, getAuthHeader } from '../helpers/auth';
+import { setupTournament } from '../helpers/tournamentSetup';
+
+/**
+ * End Match must settle MAT's own record, not just poke the server.
+ *
+ * Reported on Discord: "When the match is live and I click 'End Match' in the
+ * Admin Controls, it still shows 'LIVE' in the Matches tab."
+ *
+ * /api/rcon/end-match sent an RCON command and stopped there. MatchZy emits no
+ * event when a match is force-ended, so nothing ever told MAT, and the row
+ * stayed 'live' indefinitely.
+ *
+ * Test servers use host 0.0.0.0, which rconService treats as a fake server and
+ * answers successfully — so the real path is reachable here: the command
+ * "lands", and MAT then has to settle its own record.
+ *
+ * @tag api
+ * @tag matches
+ * @tag admin
+ */
+
+async function matchStatus(
+  request: import('@playwright/test').APIRequestContext,
+  slug: string
+): Promise<string | undefined> {
+  const response = await request.get(`/api/matches/${slug}`, { headers: getAuthHeader() });
+  if (!response.ok()) return undefined;
+  const body = await response.json();
+  return (body.match ?? body)?.status as string | undefined;
+}
+
+test.describe.serial('Ending a match', () => {
+  test(
+    'should mark the match over, not just tell the server to stop',
+    { tag: ['@api', '@matches', '@admin'] },
+    async ({ request }) => {
+      await signInViaRequest(request);
+      const setup = await setupTournament(request, { teamCount: 2, serverCount: 1 });
+      expect(setup).toBeTruthy();
+      const server = setup!.servers[0];
+
+      const matches = await (
+        await request.get('/api/matches', { headers: getAuthHeader() })
+      ).json();
+      const slug = matches.matches?.[0]?.slug as string;
+      expect(slug).toBeTruthy();
+
+      await request.post('/api/test/match-state', {
+        headers: getAuthHeader(),
+        data: { slug, status: 'live', serverId: server.id },
+      });
+
+      expect(await matchStatus(request, slug), 'match should start out live').toBe('live');
+
+      const response = await request.post('/api/rcon/end-match', {
+        headers: getAuthHeader(),
+        data: { serverId: server.id },
+      });
+      expect(response.ok(), 'end-match should succeed against this server').toBe(true);
+
+      // The reported bug: the command went out, the row was never touched, and
+      // the Matches tab kept showing LIVE.
+      await expect
+        .poll(() => matchStatus(request, slug), {
+          message: 'End Match should settle the match record, not only the server',
+          timeout: 10000,
+        })
+        .toBe('cancelled');
+    }
+  );
+
+  test(
+    'should settle the record on force cancel even with the server unreachable',
+    { tag: ['@api', '@matches', '@admin'] },
+    async ({ request }) => {
+      await signInViaRequest(request);
+      const setup = await setupTournament(request, { teamCount: 2, serverCount: 1 });
+      expect(setup).toBeTruthy();
+      const server = setup!.servers[0];
+
+      const matches = await (
+        await request.get('/api/matches', { headers: getAuthHeader() })
+      ).json();
+      const slug = matches.matches?.[0]?.slug as string;
+      expect(slug).toBeTruthy();
+
+      await request.post('/api/test/match-state', {
+        headers: getAuthHeader(),
+        data: { slug, status: 'live', serverId: server.id },
+      });
+
+      const response = await request.post(`/api/matches/${slug}/force-cancel`, {
+        headers: getAuthHeader(),
+        data: {},
+      });
+      expect(response.ok(), 'force-cancel should succeed regardless of the server').toBe(true);
+
+      await expect
+        .poll(() => matchStatus(request, slug), {
+          message: 'force-cancel should settle the match record',
+          timeout: 10000,
+        })
+        .toBe('cancelled');
+    }
+  );
+});


### PR DESCRIPTION
Vikunja #18.

## The report

> When the match is live and I click 'End Match' in the Admin Controls, it still
> shows 'LIVE' in the Matches tab.

## What it did

`/api/rcon/end-match` sent an RCON command and stopped there:

```ts
const result = await rconService.sendCommand(serverId, 'css_restart');
return res.status(statusCode).json(result);
```

MatchZy's `ResetMatch` emits **no event**, so nothing ever told MAT the match
was over. The row stayed `live` indefinitely — the Matches tab was accurately
reporting what MAT knew. Force Cancel already settled the record; End Match
never did.

It also sent the **wrong command**. `css_restart` *restarts* the match;
`css_endmatch` ends it and prints "an admin force-ended the match" to chat.
Both call `ResetMatch` in the end, but only one matches what the button says.

## The fix

The settle-up is now a shared helper: mark the match cancelled, free the server
for allocation, emit the update the UI listens for. Force Cancel used to own
that logic and End Match had none — which is exactly how they diverged — so
both now call the same code and a fix to one can't miss the other.

## Tests

Two, the first verified to fail without the fix. It reproduces the report
exactly: End Match returns success, and the match still reads `live`.

```
Error: End Match should settle the match record, not only the server
Received: "live"
```

Test servers use host `0.0.0.0`, which `rconService` already treats as a fake
server and answers successfully, so the real path is reachable in CI rather
than needing a CS2 server.

Suite: **104/104**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)