### PR TITLE
End Match now ends the match record too

### DIFF
--- a/api/src/routes/rcon.ts
+++ b/api/src/routes/rcon.ts
@@ -6,6 +6,10 @@ import { log } from '../utils/logger';
 import { getWebhookBaseUrl } from '../utils/urlHelper';
 import { getMatchZyWebhookCommands } from '../utils/matchzyRconCommands';
 import { getLastServerTestEvent } from '../services/serverConnectivityService';
+import { db } from '../config/database';
+import { emitMatchUpdate } from '../services/socketService';
+import { serverAllocationTracker } from '../services/serverAllocationTracker';
+import { matchAllocationService } from '../services/matchAllocationService';
 
 const router = Router();
 
@@ -694,7 +698,12 @@ router.post('/add-time', async (req: Request, res: Response) => {
 
 /**
  * POST /api/rcon/end-match
- * Force end the current match (css_restart / css_endmatch)
+ * Force end whatever match the server is running.
+ *
+ * This used to send `css_restart` and stop there. The server did reset, but our
+ * own record was never touched, so the match sat at `live` and the Matches tab
+ * kept showing LIVE afterwards. `ResetMatch()` emits no series_end either, so
+ * nothing else was ever going to close the record out.
  */
 router.post('/end-match', async (req: Request, res: Response) => {
   try {
@@ -707,12 +716,47 @@ router.post('/end-match', async (req: Request, res: Response) => {
       });
     }
 
-    const result = await rconService.sendCommand(serverId, 'css_restart');
-    const statusCode = result.success ? 200 : 400;
+    // css_endmatch and css_restart both call ResetMatch() in the plugin; this
+    // one announces "an admin ended the match", which is what happened.
+    const result = await rconService.sendCommand(serverId, 'css_endmatch');
+    if (!result.success) {
+      return res.status(400).json(result);
+    }
 
-    return res.status(statusCode).json(result);
+    // Close out our own record, the way force-cancel does, so the UI and the
+    // allocator both stop believing the match is still running.
+    const match = await db.queryOneAsync<{ slug: string }>(
+      `SELECT slug FROM matches
+        WHERE server_id = ?
+          AND status IN ('loaded', 'live')
+        ORDER BY id DESC
+        LIMIT 1`,
+      [serverId]
+    );
+
+    if (!match) {
+      log.info(`[RCON] Ended match on ${serverId}; no loaded or live match on record`);
+      return res.json({ ...result, endedMatchSlug: null });
+    }
+
+    await db.updateAsync(
+      'matches',
+      { status: 'cancelled', completed_at: Math.floor(Date.now() / 1000) },
+      'slug = ?',
+      [match.slug]
+    );
+    log.info(`[RCON] Match ${match.slug} ended by admin on ${serverId}`);
+
+    serverAllocationTracker.markIdle(serverId);
+    setImmediate(() => {
+      void matchAllocationService.tryImmediateAllocation();
+    });
+
+    emitMatchUpdate({ slug: match.slug, status: 'cancelled' });
+
+    return res.json({ ...result, endedMatchSlug: match.slug });
   } catch (error) {
-    console.error('Error ending match:', error);
+    log.error('Error ending match:', error as Error);
     return res.status(500).json({
       success: false,
       error: 'Failed to end match',


### PR DESCRIPTION
The admin control sent `css_restart` and stopped there. The server did reset, but our own row was never touched, so the match stayed at `live` and the Matches tab kept showing LIVE afterwards.

Nothing else was going to close it out either: `ResetMatch()` in the plugin emits no `series_end`, so there is no event for the handler to react to. The record was simply orphaned.

From Discord, 2026-01-06 (sanpy):

> When the match is live and I click "End Match" in the Admin Controls, it still shows "LIVE" in the Matches tab.

## The fix

The endpoint now closes the record the way `force-cancel` already does — marks the match cancelled with a completion timestamp, frees the server, triggers allocation, emits the match update — so the UI and the allocator both stop believing the match is running.

Also switched the command to `css_endmatch`. Both it and `css_restart` call `ResetMatch()` in MatchZy Enhanced, so the server behaves identically, but this one announces that an admin ended the match, which is what actually happened.

## Verification

Against a real CS2 server on the LAN:

- match at `loaded` → End Match → row becomes `cancelled` with `completed_at` set, response names what it ended (`endedMatchSlug: endtest2`)
- no loaded or live match on the server → command still runs, reports `endedMatchSlug: null` instead of inventing one

**No CI coverage for this one.** The endpoint requires the RCON command to land before it touches the record, and the E2E fixtures use servers that cannot answer RCON. `force-cancel` stays the tool for a server that is unreachable — it updates the record regardless and warns.

All 53 API tests pass.

## Incidental confirmation

While setting the test up, the load-refusal detection from [#151](https://github.com/sivert-io/matchzy-auto-tournament/pull/151) fired on its own:

```
MatchZy refused the match because the server still has a previous match set up.
End or cancel that match on the server, then load this one again.
```

A leftover match from an earlier run was still set up on the server. Before #151 that load would have been reported as successful and the match marked `loaded` on the wrong map.

## Also looked at, nothing to fix

The shuffle-tournament report from 2026-02-16 (*"everyone was able to join any team they wanted, regardless of the randomly created teams"*) does not reproduce. A generated 10-player shuffle serves correct rosters — two teams, five players each, no overlap — and the plugin derives each player's side from that roster (`GetPlayerTeam` in `Utility.cs`) and checks it. The likely culprit is the public team pages, which is already tracked separately. Written up on the task; it needs a question back to the reporter, not a commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)