### PR TITLE
Admin who also plays: not reproducible, now covered

### DIFF
--- a/tests/ui/veto-admin-player.spec.ts
+++ b/tests/ui/veto-admin-player.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, type Page } from '@playwright/test';
+import { signInViaRequest, stopImpersonating } from '../helpers/auth';
+import { setupTournament } from '../helpers/tournamentSetup';
+import { findMatchByTeams } from '../helpers/matches';
+import { updateTeam } from '../helpers/teams';
+import { actingSteamIdFor, executeVetoActions } from '../helpers/veto';
+import type { Team } from '../helpers/teams';
+
+/**
+ * An admin who is also a player can veto for their own team.
+ *
+ * Every other veto test drives the board through admin *impersonation*, which
+ * exercises a different identity path: the acting player is a plain player and
+ * the admin is only lending them a session. This covers the reported case
+ * instead — one human who is both `is_admin = 1` and on a team roster, acting
+ * as themselves, with no impersonation cookie in play.
+ *
+ * Veto is driven from the player's own profile page. The team page has no veto
+ * board for anyone, admin or not.
+ *
+ * ## Why these two Steam IDs are not the shared fixtures
+ *
+ * Signing in as an admin permanently sets `is_admin` on that player row, and
+ * the database is shared across the whole run. Promoting one of the fixture
+ * Steam IDs in `helpers/teams.ts` breaks every later suite that impersonates
+ * it, because an admin may not impersonate another admin. These two IDs belong
+ * to this spec alone and are added to the rosters here.
+ *
+ * @tag ui
+ * @tag veto
+ */
+const TEAM1_ADMIN_PLAYER = '76561198900000101';
+const TEAM2_ADMIN_PLAYER = '76561198900000102';
+
+test.describe.serial('Veto as an admin who also plays', () => {
+  test.setTimeout(120000);
+
+  let team1: Team;
+  let team2: Team;
+  let matchSlug: string;
+  const maps = [
+    'de_mirage',
+    'de_inferno',
+    'de_ancient',
+    'de_anubis',
+    'de_dust2',
+    'de_vertigo',
+    'de_nuke',
+  ];
+
+  test.beforeEach(async ({ page, request }) => {
+    await signInViaRequest(request);
+    await signInViaRequest(page.request);
+
+    const setup = await setupTournament(request, {
+      type: 'single_elimination',
+      format: 'bo1',
+      maps,
+      teamCount: 2,
+      serverCount: 1,
+      prefix: 'veto-admin-player',
+    });
+    expect(setup).toBeTruthy();
+    if (!setup) return;
+
+    [team1, team2] = [setup.teams[0], setup.teams[1]];
+
+    // Put this spec's own players on the rosters. The veto resolver treats the
+    // teams table as authoritative, so this is enough to make them members.
+    for (const [team, steamId] of [
+      [team1, TEAM1_ADMIN_PLAYER],
+      [team2, TEAM2_ADMIN_PLAYER],
+    ] as const) {
+      const updated = await updateTeam(request, team.id, {
+        players: [...team.players, { steamId, name: 'Admin Who Plays' }],
+      });
+      expect(updated, `should add ${steamId} to ${team.id}`).toBeTruthy();
+    }
+
+    const match = await findMatchByTeams(request, team1.id, team2.id);
+    expect(match).toBeTruthy();
+    matchSlug = match!.slug;
+  });
+
+  test.afterEach(async ({ page, request }) => {
+    await stopImpersonating(page.request);
+    await stopImpersonating(request);
+  });
+
+  /**
+   * Open the veto board on `steamId`'s own profile and ban `mapName`,
+   * asserting the resulting action request succeeds.
+   */
+  async function banAsSelf(page: Page, steamId: string, mapName: string) {
+    await page.goto(`/player/${steamId}`, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('veto-interface')).toBeVisible({ timeout: 20000 });
+
+    const actionResponse = page.waitForResponse(
+      (r) => r.url().includes(`/api/veto/${matchSlug}/action`) && r.request().method() === 'POST',
+      { timeout: 20000 }
+    );
+
+    const mapCard = page.getByTestId(`veto-map-card-${mapName}`);
+    await expect(mapCard).toBeVisible({ timeout: 20000 });
+    await mapCard.click();
+
+    const response = await actionResponse;
+    expect(
+      response.ok(),
+      `Ban of ${mapName} as admin-player ${steamId} failed: ${await response
+        .text()
+        .catch(() => 'no body')}`
+    ).toBe(true);
+  }
+
+  test(
+    'bans on the first step of the order',
+    { tag: ['@ui', '@veto'] },
+    async ({ page }) => {
+      // Sign in *as* the team1 roster member: the session's real identity is
+      // now both admin and player, with nothing impersonated.
+      expect(await signInViaRequest(page.request, TEAM1_ADMIN_PLAYER)).toBe(true);
+
+      await banAsSelf(page, TEAM1_ADMIN_PLAYER, 'de_inferno');
+    }
+  );
+
+  test(
+    'bans mid-order, once the other team has acted',
+    { tag: ['@ui', '@veto'] },
+    async ({ page, request }) => {
+      // Team1 takes its two opening bans as an ordinary impersonated player, so
+      // the turn has genuinely moved on before the admin-player acts.
+      const team1Actor = actingSteamIdFor(team1);
+      const played = await executeVetoActions(request, matchSlug, [
+        { mapName: 'de_inferno', teamSlug: team1.id, actAsSteamId: team1Actor },
+        { mapName: 'de_ancient', teamSlug: team1.id, actAsSteamId: team1Actor },
+      ]);
+      expect(played, 'team1 should complete its two opening bans').toBeTruthy();
+
+      expect(await signInViaRequest(page.request, TEAM2_ADMIN_PLAYER)).toBe(true);
+
+      await banAsSelf(page, TEAM2_ADMIN_PLAYER, 'de_dust2');
+    }
+  );
+});


### PR DESCRIPTION
## What

Vikunja #711 (Discord, tech62): *"When you are admin and a player in a team in the tournament, you can't choose maps when he's start the veto phase."*

**It does not reproduce.** Acting as themselves — `is_admin = 1`, on a roster, no impersonation — an admin can open the veto board on their own player page and ban, both on the opening step of the order and once the turn has moved on. The identity plumbing that landed with the impersonation work already resolves this correctly: `resolveViewerIdentity` returns the admin's own Steam ID as the effective identity, and `resolveViewerTeamForMatch` matches it against the team roster.

So this PR adds no fix. It adds the coverage that was missing, so the behaviour stays fixed.

## Why it was uncovered

Every existing veto test drives the board through admin **impersonation**, which is a different path: the acting player is an ordinary player and the admin is only lending them a session. The reported shape — one human who is both admin and player, with no impersonation cookie — had no test at all. `helpers/vetoUI.ts` even documents the assumption that "an admin therefore cannot drive the veto directly".

## Also checked

The team page (`/team/:teamId`) shows no veto board — but that is true for every player, admin or not. `TeamMatch.tsx` has no veto UI; veto lives on the player profile. Not a regression, and not what was reported.

## Verification

- Reverted the fix to confirm the test bites: making `resolveViewerIdentity` drop an admin's player identity fails the first test. Restored and rebuilt before the final run.
- Full suite **106 passed, 0 failed, 0 skipped** (was 104).
- Typecheck ratchet unchanged (api 45, client 73); eslint clean.

## Note on the Steam IDs

The spec adds two of its own Steam IDs to the rosters instead of reusing the shared fixtures. Signing in as an admin permanently sets `is_admin` on that row and the database is shared across the run, so promoting a fixture ID breaks every later suite that impersonates it — an admin may not impersonate another admin. The first draft did exactly that and took out three veto tests downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)