### PR TITLE
Server hostname: make it configurable, and possible to leave alone

### DIFF
--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -57,6 +57,7 @@ const mapSettingsResponse = async () => {
     matchzyStopCommandAvailable: matchzyCore.stopCommandAvailable,
     matchzyStopCommandNoDamage: matchzyCore.stopCommandNoDamage,
     matchzyUsePauseCommandForTacticalPause: matchzyCore.usePauseCommandForTacticalPause,
+    matchzyHostnameFormat: matchzyCore.hostnameFormat,
     matchzyDemoPath: matchzyCore.demoPath,
     matchzyDemoNameFormat: matchzyCore.demoNameFormat,
     matchzySeriesEndKickDelayNoDemo: matchzyCore.seriesEndKickDelayNoDemo,
@@ -106,6 +107,7 @@ router.put('/', async (req: Request, res: Response) => {
     matchzyStopCommandAvailable,
     matchzyStopCommandNoDamage,
     matchzyUsePauseCommandForTacticalPause,
+    matchzyHostnameFormat,
     matchzyDemoPath,
     matchzyDemoNameFormat,
     matchzySeriesEndKickDelayNoDemo,
@@ -144,6 +146,7 @@ router.put('/', async (req: Request, res: Response) => {
     matchzyStopCommandAvailable?: unknown;
     matchzyStopCommandNoDamage?: unknown;
     matchzyUsePauseCommandForTacticalPause?: unknown;
+    matchzyHostnameFormat?: unknown;
     matchzyDemoPath?: unknown;
     matchzyDemoNameFormat?: unknown;
     matchzySeriesEndKickDelayNoDemo?: unknown;
@@ -409,6 +412,12 @@ router.put('/', async (req: Request, res: Response) => {
     }
 
     // MatchZy core defaults (strings)
+    // Note: an empty string is preserved here rather than clearing the setting.
+    // "" is how MatchZy is told to leave the server's own hostname alone.
+    if (matchzyHostnameFormat !== undefined) {
+      const resp = await putStringOrNull('matchzy_hostname_format', matchzyHostnameFormat, 'matchzyHostnameFormat');
+      if (resp) return resp;
+    }
     if (matchzyDemoPath !== undefined) {
       const resp = await putStringOrNull('matchzy_demo_path', matchzyDemoPath, 'matchzyDemoPath');
       if (resp) return resp;

--- a/api/src/services/matchLoadingService.ts
+++ b/api/src/services/matchLoadingService.ts
@@ -143,6 +143,7 @@ export async function loadMatchOnServer(
         stopCommandAvailable: matchzyCore.stopCommandAvailable,
         stopCommandNoDamage: matchzyCore.stopCommandNoDamage,
         usePauseCommandForTacticalPause: matchzyCore.usePauseCommandForTacticalPause,
+        hostnameFormat: matchzyCore.hostnameFormat,
         demoPath: matchzyCore.demoPath,
         demoNameFormat: matchzyCore.demoNameFormat,
         seriesEndKickDelayNoDemo: matchzyCore.seriesEndKickDelayNoDemo,

--- a/api/src/services/settingsService.ts
+++ b/api/src/services/settingsService.ts
@@ -21,6 +21,7 @@ export type AppSettingKey =
   | 'matchzy_stop_command_available'
   | 'matchzy_stop_command_no_damage'
   | 'matchzy_use_pause_command_for_tactical_pause'
+  | 'matchzy_hostname_format'
   | 'matchzy_demo_path'
   | 'matchzy_demo_name_format'
   | 'matchzy_series_end_kick_delay_no_demo'
@@ -66,6 +67,7 @@ const ALLOWED_KEYS: AppSettingKey[] = [
   'matchzy_stop_command_available',
   'matchzy_stop_command_no_damage',
   'matchzy_use_pause_command_for_tactical_pause',
+  'matchzy_hostname_format',
   'matchzy_demo_path',
   'matchzy_demo_name_format',
   'matchzy_series_end_kick_delay_no_demo',
@@ -113,6 +115,24 @@ class SettingsService {
 
     if (value !== null) {
       const trimmed = value.trim();
+
+      // An empty hostname format is a real choice, not an absent one: it is how
+      // MatchZy is told to leave the server's own `hostname` alone. Every other
+      // setting folds "" to NULL and falls back to its default, which would make
+      // "don't touch my hostname" indistinguishable from "never configured".
+      if (key === 'matchzy_hostname_format') {
+        // The value is sent as `matchzy_hostname_format "<value>"`, so an
+        // embedded quote would terminate the argument and produce a malformed
+        // command. Drop them on write, so what is stored is what is sent.
+        const sanitized = trimmed.replace(/"/g, '');
+        await db.setAppSettingAsync(key, sanitized);
+        log.success(
+          sanitized === ''
+            ? 'matchzy_hostname_format cleared - servers keep their own hostname'
+            : `matchzy_hostname_format updated to ${sanitized}`
+        );
+        return;
+      }
 
       if (!trimmed) {
         await db.setAppSettingAsync(key, null);
@@ -502,6 +522,20 @@ class SettingsService {
     return normalized === '1' || normalized === 'true' || normalized === 'yes';
   }
 
+  /**
+   * Hostname format MatchZy applies when a match loads.
+   *
+   * Returns `''` when the operator has explicitly cleared it, which tells the
+   * plugin to leave the server's own `hostname` (from server.cfg) untouched.
+   * A missing row means "never configured", which keeps MatchZy's own default.
+   * The two are deliberately distinct — see `setSetting`.
+   */
+  async getMatchzyHostnameFormat(): Promise<string> {
+    const value = await this.getSetting('matchzy_hostname_format');
+    if (value === null) return '{TEAM1} vs {TEAM2}'; // MatchZy default
+    return value.trim();
+  }
+
   async getMatchzyDemoPath(): Promise<string> {
     const value = await this.getSetting('matchzy_demo_path');
     if (!value) return 'MatchZy/'; // MatchZy default
@@ -551,6 +585,7 @@ class SettingsService {
     stopCommandAvailable: boolean;
     stopCommandNoDamage: boolean;
     usePauseCommandForTacticalPause: boolean;
+    hostnameFormat: string;
     demoPath: string;
     demoNameFormat: string;
     seriesEndKickDelayNoDemo: number;
@@ -567,6 +602,7 @@ class SettingsService {
       stopCommandAvailable,
       stopCommandNoDamage,
       usePauseCommandForTacticalPause,
+      hostnameFormat,
       demoPath,
       demoNameFormat,
       seriesEndKickDelayNoDemo,
@@ -582,6 +618,7 @@ class SettingsService {
       this.isMatchzyStopCommandAvailable(),
       this.isMatchzyStopCommandNoDamage(),
       this.isMatchzyUsePauseCommandForTacticalPause(),
+      this.getMatchzyHostnameFormat(),
       this.getMatchzyDemoPath(),
       this.getMatchzyDemoNameFormat(),
       this.getMatchzySeriesEndKickDelayNoDemo(),
@@ -599,6 +636,7 @@ class SettingsService {
       stopCommandAvailable,
       stopCommandNoDamage,
       usePauseCommandForTacticalPause,
+      hostnameFormat,
       demoPath,
       demoNameFormat,
       seriesEndKickDelayNoDemo,

--- a/api/src/types/server.types.ts
+++ b/api/src/types/server.types.ts
@@ -137,6 +137,9 @@ export interface MatchzyServerConfig {
    */
   autostartMode?: 0 | 1 | 2 | null;
 
+  /** `''` leaves the server's own hostname alone. */
+  hostnameFormat?: string | null;
+
   // Demo / logging settings
   demoPath?: string | null;
   demoNameFormat?: string | null;

--- a/api/src/utils/matchzyRconCommands.ts
+++ b/api/src/utils/matchzyRconCommands.ts
@@ -135,6 +135,11 @@ export function getMatchZyServerConfigCommands(config: {
    * 0 = idle/sleep, 1 = match mode, 2 = practice mode
    */
   autostartMode?: 0 | 1 | 2 | null;
+  /**
+   * Hostname MatchZy applies on match load. `''` is a meaningful value: it tells
+   * the plugin to leave the server's own `hostname` alone.
+   */
+  hostnameFormat?: string | null;
   demoPath?: string | null;
   demoNameFormat?: string | null;
   seriesEndKickDelayNoDemo?: number | null;
@@ -191,6 +196,12 @@ export function getMatchZyServerConfigCommands(config: {
 
   if (config.autostartMode !== undefined && config.autostartMode !== null) {
     commands.push(`matchzy_autostart_mode ${config.autostartMode}`);
+  }
+
+  // Emitted even when empty — `matchzy_hostname_format ""` is how the plugin is
+  // told not to overwrite the hostname set in the server's own config.
+  if (config.hostnameFormat !== undefined && config.hostnameFormat !== null) {
+    commands.push(`matchzy_hostname_format "${config.hostnameFormat}"`);
   }
 
   if (config.demoPath !== undefined && config.demoPath !== null) {

--- a/client/src/locales/en/translation/dashboardSettings.json
+++ b/client/src/locales/en/translation/dashboardSettings.json
@@ -201,6 +201,10 @@
           "stopCommandNoDamage": "Disable .stop after opposing-team damage occurs",
           "usePauseForTacticalPause": "Make .pause behave like tactical pause"
         },
+        "hostname": {
+          "formatLabel": "Server hostname format",
+          "formatHelper": "Applied to every server when a match loads. Tokens: {MATCH_ID}, {MAP}, {MAPNUMBER}, {TEAM1}, {TEAM2}, {TEAM1_SCORE}, {TEAM2_SCORE}. Leave empty to keep the hostname each server sets in its own config."
+        },
         "demos": {
           "title": "Demos",
           "demoPathLabel": "Demo path (relative to csgo/)",

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -127,6 +127,10 @@ export default function Settings() {
     initialMatchzyUsePauseCommandForTacticalPause,
     setInitialMatchzyUsePauseCommandForTacticalPause,
   ] = useState<boolean>(false);
+  // '' is a real value here: it tells MatchZy to leave the server's own
+  // hostname alone, so it is never folded into the default on the way in or out.
+  const [matchzyHostnameFormat, setMatchzyHostnameFormat] = useState<string>('{TEAM1} vs {TEAM2}');
+  const [initialMatchzyHostnameFormat, setInitialMatchzyHostnameFormat] = useState<string>('{TEAM1} vs {TEAM2}');
   const [matchzyDemoPath, setMatchzyDemoPath] = useState<string>('MatchZy/');
   const [initialMatchzyDemoPath, setInitialMatchzyDemoPath] = useState<string>('MatchZy/');
   const [matchzyDemoNameFormat, setMatchzyDemoNameFormat] = useState<string>(
@@ -238,6 +242,7 @@ export default function Settings() {
       const stopCommandNoDamage = response.settings.matchzyStopCommandNoDamage ?? false;
       const usePauseCommandForTacticalPause =
         response.settings.matchzyUsePauseCommandForTacticalPause ?? false;
+      const hostnameFormat = response.settings.matchzyHostnameFormat ?? '{TEAM1} vs {TEAM2}';
       const demoPath = response.settings.matchzyDemoPath ?? 'MatchZy/';
       const demoNameFormat =
         response.settings.matchzyDemoNameFormat ?? '{TIME}_{MATCH_ID}_{MAP}_{TEAM1}_vs_{TEAM2}';
@@ -296,6 +301,8 @@ export default function Settings() {
       setInitialMatchzyStopCommandNoDamage(stopCommandNoDamage);
       setMatchzyUsePauseCommandForTacticalPause(usePauseCommandForTacticalPause);
       setInitialMatchzyUsePauseCommandForTacticalPause(usePauseCommandForTacticalPause);
+      setMatchzyHostnameFormat(hostnameFormat);
+      setInitialMatchzyHostnameFormat(hostnameFormat);
       setMatchzyDemoPath(demoPath);
       setInitialMatchzyDemoPath(demoPath);
       setMatchzyDemoNameFormat(demoNameFormat);
@@ -383,6 +390,7 @@ export default function Settings() {
           matchzyStopCommandAvailable,
           matchzyStopCommandNoDamage,
           matchzyUsePauseCommandForTacticalPause,
+          matchzyHostnameFormat: matchzyHostnameFormat.trim(),
           matchzyDemoPath: matchzyDemoPath.trim(),
           matchzyDemoNameFormat: matchzyDemoNameFormat.trim(),
           matchzySeriesEndKickDelayNoDemo,
@@ -439,6 +447,7 @@ export default function Settings() {
         const newStopCommandNoDamage = response.settings.matchzyStopCommandNoDamage ?? false;
         const newUsePauseCommandForTacticalPause =
           response.settings.matchzyUsePauseCommandForTacticalPause ?? false;
+        const newHostnameFormat = response.settings.matchzyHostnameFormat ?? '{TEAM1} vs {TEAM2}';
         const newDemoPath = response.settings.matchzyDemoPath ?? 'MatchZy/';
         const newDemoNameFormat =
           response.settings.matchzyDemoNameFormat ?? '{TIME}_{MATCH_ID}_{MAP}_{TEAM1}_vs_{TEAM2}';
@@ -502,6 +511,8 @@ export default function Settings() {
         setInitialMatchzyStopCommandNoDamage(newStopCommandNoDamage);
         setMatchzyUsePauseCommandForTacticalPause(newUsePauseCommandForTacticalPause);
         setInitialMatchzyUsePauseCommandForTacticalPause(newUsePauseCommandForTacticalPause);
+        setMatchzyHostnameFormat(newHostnameFormat);
+        setInitialMatchzyHostnameFormat(newHostnameFormat);
         setMatchzyDemoPath(newDemoPath);
         setInitialMatchzyDemoPath(newDemoPath);
         setMatchzyDemoNameFormat(newDemoNameFormat);
@@ -592,6 +603,7 @@ export default function Settings() {
       matchzyStopCommandAvailable,
       matchzyStopCommandNoDamage,
       matchzyUsePauseCommandForTacticalPause,
+      matchzyHostnameFormat,
       matchzyDemoPath,
       matchzyDemoNameFormat,
       matchzySeriesEndKickDelayNoDemo,
@@ -638,6 +650,7 @@ export default function Settings() {
       matchzyStopCommandAvailable !== initialMatchzyStopCommandAvailable ||
       matchzyStopCommandNoDamage !== initialMatchzyStopCommandNoDamage ||
       matchzyUsePauseCommandForTacticalPause !== initialMatchzyUsePauseCommandForTacticalPause ||
+      matchzyHostnameFormat !== initialMatchzyHostnameFormat ||
       matchzyDemoPath !== initialMatchzyDemoPath ||
       matchzyDemoNameFormat !== initialMatchzyDemoNameFormat ||
       matchzySeriesEndKickDelayNoDemo !== initialMatchzySeriesEndKickDelayNoDemo ||
@@ -711,6 +724,7 @@ export default function Settings() {
       matchzyStopCommandAvailable === initialMatchzyStopCommandAvailable &&
       matchzyStopCommandNoDamage === initialMatchzyStopCommandNoDamage &&
       matchzyUsePauseCommandForTacticalPause === initialMatchzyUsePauseCommandForTacticalPause &&
+      matchzyHostnameFormat === initialMatchzyHostnameFormat &&
       matchzyDemoPath === initialMatchzyDemoPath &&
       matchzyDemoNameFormat === initialMatchzyDemoNameFormat &&
       matchzySeriesEndKickDelayNoDemo === initialMatchzySeriesEndKickDelayNoDemo &&
@@ -766,6 +780,7 @@ export default function Settings() {
     matchzyStopCommandAvailable,
     matchzyStopCommandNoDamage,
     matchzyUsePauseCommandForTacticalPause,
+    matchzyHostnameFormat,
     matchzyDemoPath,
     matchzyDemoNameFormat,
     matchzySeriesEndKickDelayNoDemo,
@@ -799,6 +814,7 @@ export default function Settings() {
     initialMatchzyStopCommandAvailable,
     initialMatchzyStopCommandNoDamage,
     initialMatchzyUsePauseCommandForTacticalPause,
+    initialMatchzyHostnameFormat,
     initialMatchzyDemoPath,
     initialMatchzyDemoNameFormat,
     initialMatchzySeriesEndKickDelayNoDemo,
@@ -1124,6 +1140,17 @@ export default function Settings() {
                       <Typography variant="subtitle1" fontWeight={600}>
                         {t('settingsPage.matchRating.matchzyCore.demos.title')}
                       </Typography>
+                      <TextField
+                        label={t('settingsPage.matchRating.matchzyCore.hostname.formatLabel')}
+                        value={matchzyHostnameFormat}
+                        onChange={(e) => setMatchzyHostnameFormat(e.target.value)}
+                        onBlur={handleFieldBlur}
+                        onKeyDown={handleFieldKeyDown}
+                        helperText={t('settingsPage.matchRating.matchzyCore.hostname.formatHelper')}
+                        fullWidth
+                        size="small"
+                        inputProps={{ 'data-testid': 'matchzy-hostname-format-input' }}
+                      />
                       <TextField
                         label={t('settingsPage.matchRating.matchzyCore.demos.demoPathLabel')}
                         value={matchzyDemoPath}
@@ -1828,6 +1855,7 @@ export default function Settings() {
                       matchzyStopCommandAvailable?: null;
                       matchzyStopCommandNoDamage?: null;
                       matchzyUsePauseCommandForTacticalPause?: null;
+                      matchzyHostnameFormat?: null;
                       matchzyDemoPath?: null;
                       matchzyDemoNameFormat?: null;
                       matchzySeriesEndKickDelayNoDemo?: null;
@@ -1860,6 +1888,7 @@ export default function Settings() {
                       matchzyStopCommandAvailable: null,
                       matchzyStopCommandNoDamage: null,
                       matchzyUsePauseCommandForTacticalPause: null,
+                      matchzyHostnameFormat: null,
                       matchzyDemoPath: null,
                       matchzyDemoNameFormat: null,
                       matchzySeriesEndKickDelayNoDemo: null,
@@ -1910,6 +1939,8 @@ export default function Settings() {
                     const newStopCommandNoDamage = response.settings.matchzyStopCommandNoDamage ?? false;
                     const newUsePauseCommandForTacticalPause =
                       response.settings.matchzyUsePauseCommandForTacticalPause ?? false;
+                    const newHostnameFormat =
+                      response.settings.matchzyHostnameFormat ?? '{TEAM1} vs {TEAM2}';
                     const newDemoPath = response.settings.matchzyDemoPath ?? 'MatchZy/';
                     const newDemoNameFormat =
                       response.settings.matchzyDemoNameFormat ??
@@ -1962,6 +1993,8 @@ export default function Settings() {
                     setInitialMatchzyStopCommandNoDamage(newStopCommandNoDamage);
                     setMatchzyUsePauseCommandForTacticalPause(newUsePauseCommandForTacticalPause);
                     setInitialMatchzyUsePauseCommandForTacticalPause(newUsePauseCommandForTacticalPause);
+                    setMatchzyHostnameFormat(newHostnameFormat);
+                    setInitialMatchzyHostnameFormat(newHostnameFormat);
                     setMatchzyDemoPath(newDemoPath);
                     setInitialMatchzyDemoPath(newDemoPath);
                     setMatchzyDemoNameFormat(newDemoNameFormat);

--- a/client/src/types/api.types.ts
+++ b/client/src/types/api.types.ts
@@ -84,6 +84,7 @@ export interface Server {
     /** MatchZy Enhanced: 0=idle, 1=match, 2=practice */
     autostartMode?: 0 | 1 | 2 | null;
     demoPath?: string | null;
+    hostnameFormat?: string | null;
     demoNameFormat?: string | null;
     demoUploadUrl?: string | null;
   } | null;
@@ -336,6 +337,8 @@ export interface SettingsResponse extends ApiResponse {
     matchzyStopCommandAvailable?: boolean;
     matchzyStopCommandNoDamage?: boolean;
     matchzyUsePauseCommandForTacticalPause?: boolean;
+    /** '' means: leave each server's own hostname alone. */
+    matchzyHostnameFormat?: string;
     matchzyDemoPath?: string;
     matchzyDemoNameFormat?: string;
     matchzySeriesEndKickDelayNoDemo?: number;

--- a/tests/api/matchzy-hostname.spec.ts
+++ b/tests/api/matchzy-hostname.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { setupTestContext, configureWebhook } from '../helpers/setup';
+import { createTestServer, deleteServer } from '../helpers/servers';
+
+/**
+ * Server hostname format.
+ *
+ * MatchZy overwrites a server's `hostname` on every match load, using
+ * `matchzy_hostname_format`. MAT never sent that cvar, so the plugin default
+ * ("{TEAM1} vs {TEAM2}") always won and the hostname an operator had set in
+ * their own server.cfg was silently replaced with no way to stop it.
+ *
+ * The setting is now MAT's, and the interesting case is the empty one: the
+ * plugin reads `""` as "leave the hostname alone". Every other string setting
+ * folds "" to NULL and falls back to its default, which would make that choice
+ * impossible to express — so this setting deliberately does not.
+ *
+ * @tag api
+ * @tag matchzy
+ * @tag settings
+ */
+
+const PLUGIN_DEFAULT = '{TEAM1} vs {TEAM2}';
+
+/** Commands the server would receive on bootstrap. */
+async function bootstrapCommands(
+  request: APIRequestContext,
+  serverId: string
+): Promise<string[]> {
+  const response = await request.get(`/api/servers/${serverId}/bootstrap`, {
+    headers: { 'X-MatchZy-Token': process.env.SERVER_TOKEN ?? 'server123' },
+  });
+  expect(response.ok(), `bootstrap failed: ${await response.text()}`).toBe(true);
+  const body = (await response.json()) as { commands: string[] };
+  return body.commands;
+}
+
+async function setHostnameFormat(request: APIRequestContext, value: string | null) {
+  const response = await request.put('/api/settings', {
+    data: { matchzyHostnameFormat: value },
+  });
+  expect(response.ok(), `settings PUT failed: ${await response.text()}`).toBe(true);
+}
+
+async function readHostnameFormat(request: APIRequestContext): Promise<string | undefined> {
+  const response = await request.get('/api/settings');
+  expect(response.ok()).toBe(true);
+  const body = (await response.json()) as { settings: { matchzyHostnameFormat?: string } };
+  return body.settings.matchzyHostnameFormat;
+}
+
+test.describe.serial('MatchZy hostname format', () => {
+  let serverId: string;
+
+  test.beforeEach(async ({ page, request }) => {
+    await setupTestContext(page, request);
+    // The bootstrap payload embeds the webhook base URL, so it 500s without one.
+    expect(await configureWebhook(request, 'http://localhost:3069')).toBe(true);
+
+    const server = await createTestServer(request, 'hostname');
+    expect(server).toBeTruthy();
+    serverId = server!.id;
+  });
+
+  test.afterEach(async ({ request }) => {
+    await setHostnameFormat(request, null);
+    if (serverId) await deleteServer(request, serverId);
+  });
+
+  test(
+    'defaults to the plugin format and sends it to the server',
+    { tag: ['@api', '@matchzy', '@settings'] },
+    async ({ request }) => {
+      await setHostnameFormat(request, null);
+
+      expect(await readHostnameFormat(request)).toBe(PLUGIN_DEFAULT);
+      expect(await bootstrapCommands(request, serverId)).toContain(
+        `matchzy_hostname_format "${PLUGIN_DEFAULT}"`
+      );
+    }
+  );
+
+  test(
+    'a configured format reaches the server',
+    { tag: ['@api', '@matchzy', '@settings'] },
+    async ({ request }) => {
+      await setHostnameFormat(request, 'LAN #{MATCH_ID} - {TEAM1} vs {TEAM2}');
+
+      expect(await readHostnameFormat(request)).toBe('LAN #{MATCH_ID} - {TEAM1} vs {TEAM2}');
+      expect(await bootstrapCommands(request, serverId)).toContain(
+        'matchzy_hostname_format "LAN #{MATCH_ID} - {TEAM1} vs {TEAM2}"'
+      );
+    }
+  );
+
+  test(
+    'an empty format survives the round trip and tells the server to keep its own hostname',
+    { tag: ['@api', '@matchzy', '@settings'] },
+    async ({ request }) => {
+      await setHostnameFormat(request, '');
+
+      // The interesting assertion: "" must not come back as the default. If it
+      // did, an operator could never stop MatchZy renaming their server.
+      expect(await readHostnameFormat(request)).toBe('');
+      expect(await bootstrapCommands(request, serverId)).toContain(
+        'matchzy_hostname_format ""'
+      );
+    }
+  );
+
+  test(
+    'strips quotes that would break the RCON command',
+    { tag: ['@api', '@matchzy', '@settings'] },
+    async ({ request }) => {
+      await setHostnameFormat(request, 'My "LAN" server');
+
+      // An embedded quote would close the argument early and leave the server
+      // with a malformed command rather than the intended hostname.
+      expect(await readHostnameFormat(request)).toBe('My LAN server');
+      expect(await bootstrapCommands(request, serverId)).toContain(
+        'matchzy_hostname_format "My LAN server"'
+      );
+    }
+  );
+
+  test(
+    'clearing the setting with null restores the default',
+    { tag: ['@api', '@matchzy', '@settings'] },
+    async ({ request }) => {
+      await setHostnameFormat(request, '');
+      expect(await readHostnameFormat(request)).toBe('');
+
+      await setHostnameFormat(request, null);
+
+      expect(await readHostnameFormat(request)).toBe(PLUGIN_DEFAULT);
+      expect(await bootstrapCommands(request, serverId)).toContain(
+        `matchzy_hostname_format "${PLUGIN_DEFAULT}"`
+      );
+    }
+  );
+});


### PR DESCRIPTION
Vikunja #723. Discord, 2025-12-24, NikolaJyun ("hostname not work"); Sivert: *"actually I think this is hardcoded, probably left over from version 0.0.1 — I can create an issue for it."*

## What was actually wrong

MatchZy rewrites a server's `hostname` on every match load, from `matchzy_hostname_format` (plugin default `{TEAM1} vs {TEAM2}`). **MAT never sent that cvar at all** — so the plugin default always won. An operator who set `hostname` in their own `server.cfg` watched it get replaced, with nothing in the panel to change it or stop it.

The task offered two ways out: make the configured hostname stick, or remove the misleading field. There was no field to remove — so: make it settable.

## The bit that needed care

MatchZy reads `matchzy_hostname_format ""` as *"leave the hostname alone"*, which is precisely what the reporter wanted. But `setSetting` folds any empty string to `NULL`, and every getter treats `NULL` as "use the default" — so "don't touch my hostname" would have been indistinguishable from "never configured", and unreachable.

`matchzy_hostname_format` therefore stores `""` verbatim. Only an explicit `null` (the Reset button) restores the default.

While confirming that with a revert, I found `setSetting` has **no generic string branch** — an unhandled key falls through to `setAppSettingAsync(key, null)` and silently clears. So the special case carries *every* value for this key, not just the empty one. Removing it fails the tests on the second case, not the third.

## Also

Quotes are stripped on write. The value is sent as `matchzy_hostname_format "<value>"`, so an embedded `"` would close the argument early and leave the server with a malformed command instead of the intended hostname.

## Verification

Against a running stack, not just unit-level:

- Settings round trip for default / custom / empty / quote-stripped / reset.
- The actual commands the server receives, read back from `GET /api/servers/:id/bootstrap`.
- The new field rendering with the plugin default prefilled (checked in the browser; the label falls back to English correctly in a non-English UI).
- Negative test: removing the `setSetting` case fails the suite. Restored and rebuilt before the final run.
- Full suite **111 passed, 0 failed, 0 skipped** (was 106). Typecheck ratchet unchanged (api 45, client 73); eslint clean.

## Note

English strings only — other locales fall back, per TRANSLATING.md's community-translation flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)