### PR TITLE
Knife-round side selection no longer reads as warmup

### DIFF
--- a/api/src/routes/test.ts
+++ b/api/src/routes/test.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import { requireAuth } from '../middleware/auth';
 import { log } from '../utils/logger';
+import { applyMatchReport, type MatchReport } from '../services/connectionSnapshotService';
 import { db } from '../config/database';
 import { playerService } from '../services/playerService';
 import { signPlayerSteamId } from '../utils/signedPlayerCookie';
@@ -227,6 +228,37 @@ router.post('/match-state', requireAuth, async (req: Request, res: Response): Pr
   params.push(slug);
   await db.runAsync(`UPDATE matches SET ${sets.join(', ')} WHERE slug = ?`, params);
   log.warn(`[DEV-TOOLS] Set match state for ${slug}: ${sets.join(', ')}`);
+  res.json({ success: true });
+});
+
+/**
+ * Test-only helper: apply a MatchZy match report as if it arrived from a server.
+ *
+ * POST /api/test/match-report  { slug, report }
+ *
+ * Match reports reach MAT over RCON, and `rconService` short-circuits fake test
+ * servers (host 0.0.0.0) with a canned non-JSON response — so the whole
+ * `applyMatchReport` path, including the plugin-phase mapping that decides
+ * whether a match reads as WARMUP or LIVE, is otherwise unreachable from the
+ * suite. This injects a report directly.
+ *
+ * NOTE: This endpoint is only available in non-production environments.
+ */
+router.post('/match-report', requireAuth, async (req: Request, res: Response): Promise<void> => {
+  if (process.env.NODE_ENV === 'production' && !isE2eTestHelperEnabled()) {
+    res.status(403).json({ success: false, error: 'Disabled in production' });
+    return;
+  }
+
+  const { slug, report } = (req.body || {}) as { slug?: string; report?: unknown };
+
+  if (!slug || !report || typeof report !== 'object') {
+    res.status(400).json({ success: false, error: 'slug and report are required' });
+    return;
+  }
+
+  await applyMatchReport(slug, report as MatchReport);
+  log.warn(`[DEV-TOOLS] Applied injected match report for ${slug}`);
   res.json({ success: true });
 });
 

--- a/api/src/services/connectionSnapshotService.ts
+++ b/api/src/services/connectionSnapshotService.ts
@@ -468,9 +468,23 @@ function toMillis(value?: number | null): number {
   return value > 1_000_000_000_000 ? value : value * 1000;
 }
 
+/**
+ * Map a plugin phase onto the status the UIs render.
+ *
+ * The default is 'warmup', so any phase missing from this switch silently reads
+ * as WARMUP. That is how a knife round's side selection came to show the match
+ * as warming up: MatchZy Enhanced reports `knife_decision` while the winning
+ * team picks a side, and nothing here knew the name. The same held for a paused
+ * match and for a round restore, both of which are plainly live.
+ *
+ * Phase names come from `GetMatchPhaseLabel()` in MatchZy Enhanced
+ * (src/MatchReportCommand.cs); keep this in step with it.
+ */
 function mapPhaseToLiveStatus(phase?: string) {
   switch ((phase || '').toLowerCase()) {
     case 'knife':
+    case 'knife_decision':
+      // Side selection is still part of the knife stage, not a return to warmup.
       return 'knife';
     case 'going_live':
     case 'warmup_ended':
@@ -478,6 +492,10 @@ function mapPhaseToLiveStatus(phase?: string) {
       // Treat both "going_live" and "warmup_ended" as fully LIVE so that the
       // bracket and match cards flip out of WARMUP as soon as the match is
       // actually about to begin.
+      return 'live';
+    case 'paused':
+    case 'round_restore':
+      // A pause or a backup restore happens inside a live match.
       return 'live';
     case 'halftime':
       return 'halftime';
@@ -507,6 +525,9 @@ async function reconcileMatchStatusFromPhase(
   switch (normalized) {
     case 'live':
     case 'knife':
+    case 'knife_decision':
+    case 'paused':
+    case 'round_restore':
     case 'halftime':
       targetStatus = 'live';
       break;

--- a/tests/api/match-phase.spec.ts
+++ b/tests/api/match-phase.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { setupTestContext } from '../helpers/setup';
+import { setupTournament } from '../helpers/tournamentSetup';
+import { findMatchByTeams } from '../helpers/matches';
+import type { Team } from '../helpers/teams';
+
+/**
+ * Plugin phase → match status.
+ *
+ * `mapPhaseToLiveStatus` defaults to 'warmup', so every phase name it does not
+ * know silently reads as WARMUP. MatchZy Enhanced reports `knife_decision`
+ * while the knife winner picks a side, and MAT had no case for it — so the UI
+ * dropped back to WARMUP mid-knife, which is the reported bug. `paused` and
+ * `round_restore` had the same hole: both happen inside a live match.
+ *
+ * Reports normally arrive over RCON, which is stubbed for fake test servers, so
+ * these inject one through the test-only endpoint instead.
+ *
+ * @tag api
+ * @tag matchzy
+ * @tag regression
+ */
+
+/** A minimal match report carrying just the phase and a map/score block. */
+function reportWithPhase(phase: string) {
+  return {
+    match: {
+      phase,
+      map: { name: 'de_mirage', index: 0, number: 1, total: 1, round: 7 },
+      score: { team1: 4, team2: 3, series: { team1: 0, team2: 0 } },
+    },
+  };
+}
+
+async function applyPhase(request: APIRequestContext, slug: string, phase: string) {
+  const res = await request.post('/api/test/match-report', {
+    data: { slug, report: reportWithPhase(phase) },
+  });
+  expect(res.ok(), `injecting phase ${phase} failed: ${await res.text()}`).toBe(true);
+}
+
+async function liveStatus(
+  request: APIRequestContext,
+  teamId: string
+): Promise<string | undefined> {
+  const res = await request.get(`/api/team/${teamId}/match`);
+  expect(res.ok()).toBe(true);
+  const body = (await res.json()) as { match?: { liveStats?: { status?: string } } };
+  return body.match?.liveStats?.status;
+}
+
+test.describe.serial('Plugin phase to match status', () => {
+  let team1: Team;
+  let team2: Team;
+  let slug: string;
+
+  test.beforeEach(async ({ page, request }) => {
+    await setupTestContext(page, request);
+
+    const setup = await setupTournament(request, {
+      type: 'single_elimination',
+      format: 'bo1',
+      maps: ['de_mirage', 'de_inferno', 'de_ancient', 'de_anubis', 'de_dust2', 'de_vertigo', 'de_nuke'],
+      teamCount: 2,
+      serverCount: 1,
+      prefix: 'phase',
+    });
+    expect(setup).toBeTruthy();
+    [team1, team2] = [setup!.teams[0], setup!.teams[1]];
+
+    const match = await findMatchByTeams(request, team1.id, team2.id);
+    expect(match?.slug).toBeTruthy();
+    slug = match!.slug;
+
+    // A match the plugin is reporting on has been loaded onto a server. Without
+    // this the status reconciliation has nothing to move forward from.
+    const state = await request.post('/api/test/match-state', {
+      data: { slug, status: 'loaded', serverId: setup!.servers[0].id },
+    });
+    expect(state.ok()).toBe(true);
+  });
+
+  test(
+    'side selection after the knife round does not read as warmup',
+    { tag: ['@api', '@matchzy', '@regression'] },
+    async ({ request }) => {
+      await applyPhase(request, slug, 'knife_decision');
+
+      // The bug: with no case for `knife_decision` this fell to the 'warmup'
+      // default, so the board dropped out of the knife round while the winning
+      // team was still choosing a side.
+      expect(await liveStatus(request, team1.id)).toBe('knife');
+
+      const match = await findMatchByTeams(request, team1.id, team2.id);
+      expect(match?.status).toBe('live');
+    }
+  );
+
+  test(
+    'a paused match stays live',
+    { tag: ['@api', '@matchzy', '@regression'] },
+    async ({ request }) => {
+      await applyPhase(request, slug, 'paused');
+
+      expect(await liveStatus(request, team1.id)).toBe('live');
+      const match = await findMatchByTeams(request, team1.id, team2.id);
+      expect(match?.status).toBe('live');
+    }
+  );
+
+  test(
+    'a round restore stays live',
+    { tag: ['@api', '@matchzy', '@regression'] },
+    async ({ request }) => {
+      await applyPhase(request, slug, 'round_restore');
+
+      expect(await liveStatus(request, team1.id)).toBe('live');
+      const match = await findMatchByTeams(request, team1.id, team2.id);
+      expect(match?.status).toBe('live');
+    }
+  );
+
+  test(
+    'CONTROL: a real warmup still reads as warmup',
+    { tag: ['@api', '@matchzy'] },
+    async ({ request }) => {
+      await applyPhase(request, slug, 'warmup');
+
+      // Guards the fix from the lazy version of itself — mapping everything to
+      // 'live' would pass all three tests above.
+      expect(await liveStatus(request, team1.id)).toBe('warmup');
+
+      const match = await findMatchByTeams(request, team1.id, team2.id);
+      expect(match?.status).toBe('loaded');
+    }
+  );
+});


### PR DESCRIPTION
Vikunja #722. Discord PoC thread, 2025-12-30, Sivert: *"if you use knife to decide side, the UI is a bit buggy. It looks like it goes back to warmup, but in reality they are picking sides and MatchZy says 'round ended'. It should go back to live once they chose their side."*

## Cause

`mapPhaseToLiveStatus` ends in `default: return 'warmup'`. Any plugin phase not named in its switch silently renders as WARMUP.

MatchZy Enhanced reports **`knife_decision`** while the knife winner picks a side (`GetMatchPhaseLabel()` in `src/MatchReportCommand.cs`). MAT had no case for it â€” so the board fell to the default and dropped out of the knife round exactly while the decision was being made.

## Two siblings, same hole

Reading the plugin's phase list against MAT's switch, `knife_decision` was not alone:

| phase | was | now |
|---|---|---|
| `knife_decision` | warmup | knife |
| `paused` | warmup | live |
| `round_restore` | warmup | live |

A paused live match showing WARMUP is arguably worse than the reported one. `reconcileMatchStatusFromPhase` had the same gap, so none of the three moved the match row forward either â€” its progression guard only ever moves forward, so a completed match still can't regress.

## Testability

Match reports reach MAT over RCON, and `rconService` short-circuits fake test servers (host `0.0.0.0`) with a canned non-JSON response. The entire `applyMatchReport` path â€” including this mapping â€” was therefore unreachable from the suite, which is how the gap survived.

This adds a test-only injection endpoint next to the existing `/api/test/match-state`, same `requireAuth` + non-production guard. That path is also what sits behind the live-updates reports in Vikunja #714, so it should earn its keep again.

## Verification

- Negative test: reverting the mapping fails the knife test. Restored and rebuilt before the final run.
- A **control** test pins that a real `warmup` still reads as warmup and leaves the row on `loaded` â€” without it, mapping everything to `live` would pass the other three.
- Full suite **115 passed, 0 failed, 0 skipped** (was 111). Ratchet unchanged (api 45, client 73); eslint clean.

## Not covered

The plugin side is untouched, and does not need to be. I checked
`MapTournamentStatusToMatHeartbeatStatus` in `src/MatHeartbeat.cs`, which falls
through to `_ => "error"` — but it maps `tournamentStatus`, a different field
from the phase label. The nine values the plugin actually sets (error, halftime,
idle, knife, loading, paused, postgame, queued, warmup) are all covered, and
`knife_decision` never reaches it.
