### PR TITLE
Hold the knife round through side selection (the actual #722 fix)

### DIFF
--- a/api/src/services/matchEventHandler.ts
+++ b/api/src/services/matchEventHandler.ts
@@ -229,7 +229,13 @@ export async function handleMatchEvent(event: MatchZyEvent): Promise<void> {
       });
       const match = await resolveMatch(event.matchid);
       if (match) {
-        updateLiveStats(match, { status: 'warmup' });
+        // The knife winner still has to pick a side, and MatchZy emits no event
+        // for that choice — the next signal is `going_live`. Reporting warmup
+        // here dropped the UI out of the knife round for the whole selection
+        // window (matchzy_side_selection_time, 60s by default), which is what
+        // users saw: "it looks like it goes back to warmup, but they are
+        // picking sides". Stay on 'knife' until the match actually starts.
+        updateLiveStats(match, { status: 'knife' });
       }
       break;
     }

--- a/tests/api/knife-side-selection.spec.ts
+++ b/tests/api/knife-side-selection.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { setupTestContext } from '../helpers/setup';
+import { setupTournament } from '../helpers/tournamentSetup';
+import { findMatchByTeams } from '../helpers/matches';
+import type { Team } from '../helpers/teams';
+
+/**
+ * Knife round → side selection → live.
+ *
+ * MatchZy emits `knife_round_started`, then `knife_round_ended` carrying the
+ * winner, then `going_live` once the winner has chosen a side. It emits nothing
+ * for the choice itself, so the gap between the last two events is the whole
+ * selection window — `matchzy_side_selection_time`, 60 seconds by default.
+ *
+ * MAT used to report 'warmup' on `knife_round_ended`, so for that entire window
+ * the UI dropped out of the knife round and claimed the match was warming up.
+ * Verified against a real CS2 server: the event order below is what a live
+ * knife round actually produces.
+ *
+ * @tag api
+ * @tag matchzy
+ * @tag regression
+ */
+
+const HEADERS = {
+  'Content-Type': 'application/json',
+  'X-MatchZy-Token': process.env.SERVER_TOKEN ?? 'server123',
+};
+
+async function sendEvent(request: APIRequestContext, slug: string, payload: object) {
+  const res = await request.post(`/api/events/${slug}`, { headers: HEADERS, data: payload });
+  expect(res.ok(), `event rejected: ${await res.text()}`).toBe(true);
+}
+
+async function liveStatus(request: APIRequestContext, slug: string): Promise<string | undefined> {
+  const res = await request.get(`/api/events/live/${slug}`);
+  expect(res.ok()).toBe(true);
+  return ((await res.json()) as { status?: string }).status;
+}
+
+test.describe.serial('Knife round side selection', () => {
+  let team1: Team;
+  let team2: Team;
+  let slug: string;
+
+  test.beforeEach(async ({ page, request }) => {
+    await setupTestContext(page, request);
+
+    const setup = await setupTournament(request, {
+      type: 'single_elimination',
+      format: 'bo1',
+      maps: ['de_mirage', 'de_inferno', 'de_ancient', 'de_anubis', 'de_dust2', 'de_vertigo', 'de_nuke'],
+      teamCount: 2,
+      serverCount: 1,
+      prefix: 'knife-side',
+    });
+    expect(setup).toBeTruthy();
+    [team1, team2] = [setup!.teams[0], setup!.teams[1]];
+
+    const match = await findMatchByTeams(request, team1.id, team2.id);
+    expect(match?.slug).toBeTruthy();
+    slug = match!.slug;
+  });
+
+  test(
+    'stays on the knife round while the winner picks a side, then goes live',
+    { tag: ['@api', '@matchzy', '@regression'] },
+    async ({ request }) => {
+      await sendEvent(request, slug, {
+        event: 'knife_round_started',
+        matchid: slug,
+        map_number: 0,
+      });
+      expect(await liveStatus(request, slug)).toBe('knife');
+
+      await sendEvent(request, slug, {
+        event: 'knife_round_ended',
+        matchid: slug,
+        map_number: 0,
+        winner: 'team1',
+      });
+
+      // The reported bug: this used to report 'warmup', so the board left the
+      // knife round for the entire side-selection window.
+      expect(
+        await liveStatus(request, slug),
+        'side selection is still the knife stage, not warmup'
+      ).toBe('knife');
+
+      await sendEvent(request, slug, {
+        event: 'going_live',
+        matchid: slug,
+        map_number: 0,
+      });
+
+      expect(await liveStatus(request, slug)).toBe('live');
+    }
+  );
+});


### PR DESCRIPTION
Vikunja #722, for real this time. Found by running an actual knife round on the LAN servers.

## What a real knife round emits

```
knife_round_started  ->  knife_round_ended  ->  going_live
```

That's it. **MatchZy emits no event for the side choice itself** — I checked every event the plugin defines. So the gap between the last two is the entire selection window: `matchzy_side_selection_time`, **60 seconds by default**.

MAT's handler did this:

```js
case 'knife_round_ended':
  updateLiveStats(match, { status: 'warmup' });   // <- for the next 60s
```

So for that whole window the board left the knife round and said the match was warming up. That is exactly the report: *"It looks like it goes back to warmup, but in reality they are picking sides."*

Staying on `'knife'` until `going_live` also matches the reporter's own expectation — *"It should go back to live once they chose their side."*

## About #164

#164 fixed the same class of bug (`knife_decision` falling through to a `'warmup'` default) in `mapPhaseToLiveStatus`. **That path does not run on real servers.** It reads the plugin's match report over RCON, and on a live server both report commands return an empty string:

```
command: matchzy_match_report, success: true, response: ""
command: css_match_report,     success: true, response: ""
[ERROR] [MatchReport] Unable to retrieve match report
```

The plugin builds the report inside `Server.NextFrame(...)` and then `Task.Run(async ...)`, so `ReplyToCommand` fires long after the RCON response has been sent. The HTTP upload alternative is unconfigured (`matchzy_report_endpoint` defaults to empty, MAT never sets it, and MAT has no `/api/events/report` route).

#164 is still correct and its tests still pin the mapping — but it was not what users were seeing, and I should have caught that before claiming the bug fixed. This PR is the live path.

That dead report pipeline is very likely also behind Vikunja #714 (live updates unreliable, servers showing offline while online) — filing separately rather than widening this PR.

## Verification

- Real knife round on LAN server 1, event order confirmed from MAT's own logs.
- Negative test: reverting to `'warmup'` fails the new test with `Received: "warmup"`.
- Full suite **116 passed, 0 failed, 0 skipped** (was 115). Ratchet unchanged; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)