### PR TITLE
Tell servers where to push match reports (fixes the dead report pipeline)

### DIFF
--- a/api/src/utils/matchzyRconCommands.ts
+++ b/api/src/utils/matchzyRconCommands.ts
@@ -18,6 +18,14 @@ export function getMatchZyWebhookCommands(
     `matchzy_remote_log_url "${webhookUrl}"`,
     `matchzy_remote_log_header_key "X-MatchZy-Token"`,
     `matchzy_remote_log_header_value "${serverToken}"`,
+    // Where the plugin pushes full match reports. Without this the plugin's
+    // upload is skipped and the report is only offered as the reply to an RCON
+    // command — which it builds asynchronously, long after the RCON response has
+    // been sent, so MAT reads an empty string and drops the report entirely.
+    // `matchzy_report_server_id` needs no command: the plugin sets it from
+    // `matchzy_server_id`, which is already sent during initialization.
+    `matchzy_report_endpoint "${baseUrl}/api/events/report"`,
+    `matchzy_report_token "${serverToken}"`,
     `get5_check_auths true`, // Enable auth check to prevent random players
   ];
 }

--- a/tests/api/matchzy-hostname.spec.ts
+++ b/tests/api/matchzy-hostname.spec.ts
@@ -124,6 +124,27 @@ test.describe.serial('MatchZy hostname format', () => {
   );
 
   test(
+    'tells the server where to push match reports',
+    { tag: ['@api', '@matchzy', '@regression'] },
+    async ({ request }) => {
+      const commands = await bootstrapCommands(request, serverId);
+
+      // Without these the plugin skips its HTTP upload and only offers the
+      // report as the reply to an RCON command, which it builds asynchronously
+      // — long after the RCON response has been sent. MAT then reads an empty
+      // string and every match report is lost, taking phase reconciliation and
+      // connection snapshots with it.
+      expect(commands).toContain(
+        `matchzy_report_endpoint "http://localhost:3069/api/events/report"`
+      );
+      expect(
+        commands.some((c) => c.startsWith('matchzy_report_token ')),
+        'the plugin needs a token to authenticate its upload'
+      ).toBe(true);
+    }
+  );
+
+  test(
     'clearing the setting with null restores the default',
     { tag: ['@api', '@matchzy', '@settings'] },
     async ({ request }) => {


### PR DESCRIPTION
Vikunja #714. Found by testing against the real LAN servers.

## The pipeline was dead

Every real server, every time:

```
command: matchzy_match_report, success: true, response: ""
command: css_match_report,     success: true, response: ""
[ERROR] [MatchReport] Unable to retrieve match report
```

`OnMatchReportCommand` builds the payload inside `Server.NextFrame(...)` and then `Task.Run(async ...)`, so `ReplyToCommand` fires long after the RCON response has been sent. **Pulling a report over RCON cannot work** — not a timeout, not a size limit (2 KB responses come back fine), just a race the caller always loses.

## It was never meant to be pulled

The plugin already **pushes** full reports over HTTP on eight triggers — `player_connect`, `player_disconnect`, `player_ready`, `player_unready`, `warmup_start`, `post_knife_warmup`, `round_start`, `round_end` — and MAT already has `POST /api/events/report` to receive them, complete with token auth and a `{success:true}` reply of exactly the shape the plugin's upload check wants.

Nobody connected the two. The upload is skipped unless `matchzy_report_endpoint` is set, and MAT never set it. So both halves have been sitting there, finished, doing nothing.

The fix is two commands. `matchzy_report_server_id` needs none — the plugin derives it from `matchzy_server_id`, which MAT already sends.

## What was broken by it

`applyMatchReport` never ran, so everything downstream was dead code in production:

- plugin phase reconciliation (`reconcileMatchStatusFromPhase`)
- `mapPhaseToLiveStatus` — which is why #164 "fixed" #722 without changing anything users could see
- the connection snapshot refresh

That lines up with #714's symptoms: servers showing offline while online, state stale until a hard refresh, a player connected but shown offline for 15+ minutes.

## Verified on real hardware

- After re-init, the real server reports `matchzy_report_endpoint = http://192.168.50.181:3069/api/events/report`.
- With no match loaded, reports arrive and are correctly rejected `404` — three POSTs, the plugin's retry backoff. The transport works.
- With a match loaded: `[MatchReport] Report ingested via plugin POST`, and the live status carries `mapName: de_dust2` — **a field no webhook event supplies**, so it can only have come through `applyMatchReport`.

Full suite **117 passed, 0 failed, 0 skipped**. Ratchet unchanged; eslint clean.

## Follow-up worth doing separately

The plugin's RCON reply path is still broken for anyone who calls it directly. Either make it reply synchronously or drop the pretence that it can. Not needed for MAT now that the push path is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)