### PR TITLE
The release workflow has never worked: wrong Docker Hub secret names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,15 +29,15 @@ jobs:
     env:
       # Required secrets:
       # - DISCORD_WEBHOOK_URL: Discord incoming webhook URL used by scripts/discord-webhook.sh
-      # - DOCKERHUB_USERNAME: Docker Hub username used for docker login and image naming
-      # - DOCKERHUB_TOKEN: Docker Hub access token/password for docker login
+      # - DOCKER_USERNAME: Docker Hub username used for docker login and image naming
+      # - DOCKER_PASSWORD: Docker Hub access token/password for docker login
       # Optional secret:
       # - RELEASE_GITHUB_TOKEN: PAT with repo permissions for gh CLI operations (PR create/merge, tags, release)
       #   If omitted, workflow falls back to the auto-generated github.token.
       GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
       GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       RELEASE_NON_INTERACTIVE: "true"
       RELEASE_RUN_TESTS: "false"
     steps:
@@ -71,8 +71,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Run release script
         shell: bash


### PR DESCRIPTION
Found while cutting the v2.1.0 release, which failed at `Login to Docker Hub`:

```
DOCKER_USERNAME:
##[error]Username and password required
```

## Cause

The workflow references secrets that do not exist in this repository:

| workflow wants | repo actually has | set |
|---|---|---|
| `DOCKERHUB_USERNAME` | `DOCKER_USERNAME` | 2025-11-09 |
| `DOCKERHUB_TOKEN` | `DOCKER_PASSWORD` | 2025-11-09 |

The workflow was added on 2026-05-19 (`a1e38f5`) with the `DOCKERHUB_*` names, and they have never matched. The last real release — v2.0.14, February — predates the workflow, so **no release has ever succeeded through it** and nothing surfaced the breakage.

## Fix

Point the workflow at the names that exist. The alternative — adding `DOCKERHUB_*` secrets — means re-issuing a Docker Hub token for no benefit, and leaves two near-identical secret pairs to confuse the next person.

## Failure was clean

It died before `Run release script`, so nothing was half-done: no version bump, no tag, no GitHub release, no image. `main` is still 2.0.14 and the release can simply be re-run once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)