### PR TITLE
Copy Console Command now works over plain HTTP

### DIFF
--- a/client/src/components/team/MatchInfoCard.tsx
+++ b/client/src/components/team/MatchInfoCard.tsx
@@ -3,6 +3,7 @@ import { Box, Card, CardContent, Typography, Alert } from '@mui/material';
 import PeopleIcon from '@mui/icons-material/People';
 import { getMapData } from '../../constants/maps';
 import { VetoInterface } from '../veto/VetoInterface';
+import { copyTextToClipboard } from '../../utils/clipboard';
 import type { Team, TeamMatchInfo, VetoState, MatchLiveStats, PlayersResponse } from '../../types';
 // Note: status color is handled by higher-level components; keep imports minimal here.
 import {
@@ -302,7 +303,7 @@ export function MatchInfoCard({
     setTimeout(() => setConnected(false), 3000);
   };
 
-  const handleCopyIP = () => {
+  const handleCopyIP = async () => {
     if (!match.server) return;
     const connectCommand = `connect ${match.server.host}:${match.server.port}${
       match.server.password ? `; password ${match.server.password}` : ''
@@ -311,30 +312,21 @@ export function MatchInfoCard({
     // Reset any previous fallback state
     setCopyFallbackCommand(null);
 
-    // Prefer modern clipboard API when available and allowed
-    if (navigator.clipboard && (window as typeof globalThis).isSecureContext) {
-      navigator.clipboard
-        .writeText(connectCommand)
-        .then(() => {
-          setCopied(true);
-          setTimeout(() => setCopied(false), 2000);
-        })
-        .catch((err) => {
-          console.warn('Clipboard write failed, falling back to manual copy:', err);
-          setCopyFallbackCommand(connectCommand);
-          showError(
-            'Unable to copy connect command automatically. Command is shown below so you can copy it manually.'
-          );
-        });
+    // Copying works over plain HTTP too — `copyTextToClipboard` falls back to
+    // execCommand where `navigator.clipboard` does not exist. Showing the
+    // command is the last resort, not the first response to a non-HTTPS origin:
+    // most LAN users can simply have the button work.
+    const copiedOk = await copyTextToClipboard(connectCommand);
+
+    if (copiedOk) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
       return;
     }
 
-    // Fallback for non-secure contexts (e.g. plain HTTP) or missing API:
-    // show the command so the user can copy it manually, and surface a clear
-    // warning so they know why the button did not copy to the clipboard.
     setCopyFallbackCommand(connectCommand);
     showError(
-      'Your browser blocked automatic copying (non-HTTPS or missing clipboard access). Command is shown below so you can copy it manually.'
+      'Your browser blocked copying. The command is shown below so you can copy it manually.'
     );
   };
 

--- a/client/src/utils/clipboard.ts
+++ b/client/src/utils/clipboard.ts
@@ -1,0 +1,44 @@
+/**
+ * Copying text without a secure context.
+ *
+ * `navigator.clipboard` only exists on HTTPS and localhost. Plenty of MAT
+ * instances run over plain HTTP on a LAN, where the modern API is simply absent
+ * — so a button that only calls it does nothing at all, which is exactly what
+ * users reported about "Copy Console Command".
+ *
+ * `document.execCommand('copy')` is deprecated but still works in non-secure
+ * contexts in every browser MAT targets, so it is the fallback rather than the
+ * last resort. Callers should still handle `false`: a browser may refuse both,
+ * and the only honest answer then is to show the text and let the user copy it.
+ */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (error) {
+      // Permission denied or a hostile embedding context — try the old way.
+      console.warn('Clipboard API write failed, falling back to execCommand:', error);
+    }
+  }
+
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  // Keep it off-screen but still focusable; `display: none` cannot be selected.
+  textArea.style.position = 'fixed';
+  textArea.style.left = '-999999px';
+  textArea.style.top = '-999999px';
+  textArea.setAttribute('readonly', '');
+  document.body.appendChild(textArea);
+
+  try {
+    textArea.focus();
+    textArea.select();
+    return document.execCommand('copy');
+  } catch (error) {
+    console.error('Fallback copy failed:', error);
+    return false;
+  } finally {
+    document.body.removeChild(textArea);
+  }
+}

--- a/client/src/utils/teamLinks.ts
+++ b/client/src/utils/teamLinks.ts
@@ -1,3 +1,5 @@
+import { copyTextToClipboard } from './clipboard';
+
 /**
  * Team link utilities
  * Centralized logic for generating and handling team match URLs
@@ -11,38 +13,13 @@ export function getTeamMatchUrl(teamId: string): string {
 }
 
 /**
- * Copy team match URL to clipboard
- * Fallback for insecure contexts (non-HTTPS/localhost)
+ * Copy team match URL to clipboard.
+ *
+ * Works over plain HTTP too — see `copyTextToClipboard`.
  */
 export async function copyTeamMatchUrl(teamId: string): Promise<boolean> {
   try {
-    const url = getTeamMatchUrl(teamId);
-    
-    // Modern Clipboard API (requires secure context)
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      await navigator.clipboard.writeText(url);
-      return true;
-    }
-    
-    // Fallback for insecure contexts
-    const textArea = document.createElement('textarea');
-    textArea.value = url;
-    textArea.style.position = 'fixed';
-    textArea.style.left = '-999999px';
-    textArea.style.top = '-999999px';
-    document.body.appendChild(textArea);
-    textArea.focus();
-    textArea.select();
-    
-    try {
-      const successful = document.execCommand('copy');
-      document.body.removeChild(textArea);
-      return successful;
-    } catch (err) {
-      document.body.removeChild(textArea);
-      console.error('Fallback copy failed:', err);
-      return false;
-    }
+    return await copyTextToClipboard(getTeamMatchUrl(teamId));
   } catch (error) {
     console.error('Failed to copy team link:', error);
     return false;

--- a/tests/ui/copy-connect-command.spec.ts
+++ b/tests/ui/copy-connect-command.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect, type Page } from '@playwright/test';
+import { ensureSignedIn, signInViaRequest, impersonatePlayer, stopImpersonating } from '../helpers/auth';
+import { setupTournament } from '../helpers/tournamentSetup';
+import { findMatchByTeams } from '../helpers/matches';
+import { actingSteamIdFor } from '../helpers/veto';
+import type { Team } from '../helpers/teams';
+
+/**
+ * "Copy Console Command" without a secure context.
+ *
+ * `navigator.clipboard` exists only on HTTPS and localhost. Plenty of MAT
+ * instances run over plain HTTP on a LAN, and there the button used to do
+ * nothing at all — the reported bug.
+ *
+ * The suite itself runs on localhost, which *is* a secure context, so these
+ * tests remove `navigator.clipboard` before the page loads to reproduce what a
+ * LAN user actually gets. `document.execCommand` is stubbed so the assertions
+ * do not depend on a real system clipboard, which headless browsers do not
+ * reliably provide.
+ *
+ * @tag ui
+ * @tag regression
+ */
+
+/** Reproduce a plain-HTTP origin, with execCommand reporting `success`. */
+async function withInsecureClipboard(page: Page, success: boolean) {
+  await page.addInitScript((execSucceeds) => {
+    Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
+    Object.defineProperty(window, 'isSecureContext', { value: false, configurable: true });
+    (window as unknown as { __copiedText?: string }).__copiedText = undefined;
+    document.execCommand = ((command: string) => {
+      if (command !== 'copy') return false;
+      const active = document.activeElement as HTMLTextAreaElement | null;
+      (window as unknown as { __copiedText?: string }).__copiedText = active?.value;
+      return execSucceeds;
+    }) as typeof document.execCommand;
+  }, success);
+}
+
+test.describe.serial('Copy console command over plain HTTP', () => {
+  test.setTimeout(120000);
+
+  let team1: Team;
+  let team2: Team;
+
+  test.beforeEach(async ({ page, request }) => {
+    await ensureSignedIn(page);
+    await signInViaRequest(request);
+
+    const setup = await setupTournament(request, {
+      type: 'single_elimination',
+      format: 'bo1',
+      maps: ['de_mirage', 'de_inferno', 'de_ancient', 'de_anubis', 'de_dust2', 'de_vertigo', 'de_nuke'],
+      teamCount: 2,
+      serverCount: 1,
+      prefix: 'copy-cmd',
+    });
+    expect(setup).toBeTruthy();
+    [team1, team2] = [setup!.teams[0], setup!.teams[1]];
+
+    const match = await findMatchByTeams(request, team1.id, team2.id);
+    expect(match?.slug).toBeTruthy();
+
+    // The connect panel only appears once a server is actually assigned *and*
+    // reporting itself online — otherwise the page sits on "Waiting for Server
+    // Assignment" and there is no button to click.
+    const serverId = setup!.servers[0].id;
+    const state = await request.post('/api/test/match-state', {
+      data: { slug: match!.slug, serverId, status: 'loaded' },
+    });
+    expect(state.ok()).toBe(true);
+
+    // The panel treats the server as reachable once live stats exist, which is
+    // the path that actually works without a real CS2 server: priming the
+    // status cache does not help, because the player route queries the server
+    // over RCON rather than reading the cache.
+    const live = await request.post(`/api/events/${match!.slug}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-MatchZy-Token': process.env.SERVER_TOKEN ?? 'server123',
+      },
+      data: { event: 'going_live', matchid: match!.slug, map_number: 0 },
+    });
+    expect(live.ok()).toBe(true);
+  });
+
+  test.afterEach(async ({ page, request }) => {
+    await stopImpersonating(page.request);
+    await stopImpersonating(request);
+  });
+
+  test(
+    'copies the command even though the Clipboard API is unavailable',
+    { tag: ['@ui', '@regression'] },
+    async ({ page }) => {
+      const steamId = actingSteamIdFor(team1);
+      expect(await impersonatePlayer(page.request, steamId)).toBe(true);
+
+      await withInsecureClipboard(page, true);
+      await page.goto(`/player/${steamId}`, { waitUntil: 'domcontentloaded' });
+
+      const copyButton = page.getByRole('button', { name: /Copy Console Command/i });
+      await expect(copyButton).toBeVisible({ timeout: 20000 });
+      await copyButton.click();
+
+      // The button reporting success is the whole point: on a LAN it used to do
+      // nothing whatsoever.
+      await expect(page.getByRole('button', { name: /Copied/i })).toBeVisible({ timeout: 10000 });
+
+      const copiedText = await page.evaluate(
+        () => (window as unknown as { __copiedText?: string }).__copiedText
+      );
+      expect(copiedText, 'the connect command should be what got copied').toContain('connect ');
+    }
+  );
+
+  test(
+    'shows the command to copy by hand when the browser refuses entirely',
+    { tag: ['@ui', '@regression'] },
+    async ({ page }) => {
+      const steamId = actingSteamIdFor(team1);
+      expect(await impersonatePlayer(page.request, steamId)).toBe(true);
+
+      await withInsecureClipboard(page, false);
+      await page.goto(`/player/${steamId}`, { waitUntil: 'domcontentloaded' });
+
+      const copyButton = page.getByRole('button', { name: /Copy Console Command/i });
+      await expect(copyButton).toBeVisible({ timeout: 20000 });
+      await copyButton.click();
+
+      // Last resort, but never silence.
+      await expect(page.getByText(/Run in console:/i)).toBeVisible({ timeout: 10000 });
+    }
+  );
+});

--- a/tests/ui/copy-connect-command.spec.ts
+++ b/tests/ui/copy-connect-command.spec.ts
@@ -30,7 +30,7 @@ async function withInsecureClipboard(page: Page, success: boolean) {
     (window as unknown as { __copiedText?: string }).__copiedText = undefined;
     document.execCommand = ((command: string) => {
       if (command !== 'copy') return false;
-      const active = document.activeElement as HTMLTextAreaElement | null;
+      const active = document.activeElement as { value?: string } | null;
       (window as unknown as { __copiedText?: string }).__copiedText = active?.value;
       return execSucceeds;
     }) as typeof document.execCommand;


### PR DESCRIPTION
Vikunja #721. Discord, 2026-01-05, sanpy: *"the 'Copy Console Command' button is not working. Connect to server works as intended."* Sivert's diagnosis was right: the Clipboard API only exists on HTTPS and localhost.

## What was already there, and what wasn't

The silent failure had already been fixed — the button showed the command as a caption and asked you to copy it by hand. But **it still never copied.** For a LAN user on plain HTTP the button remained, functionally, a label.

`document.execCommand('copy')` is deprecated but works in non-secure contexts in every browser MAT targets. It belongs in the path as a fallback, not skipped entirely. So the button now actually copies, and showing the text is the last resort for a browser that refuses both — not the standard response to a non-HTTPS origin.

## Drift between the two call sites

`copyTeamMatchUrl` already had the execCommand fallback inline; the connect command never got it. Both now share one `copyTextToClipboard` helper, so the next call site inherits the right behaviour instead of picking one of two.

## Testing this honestly

The suite runs on `localhost`, which **is** a secure context — so a naive test would exercise the Clipboard API path and prove nothing about the reported bug. The tests remove `navigator.clipboard` and set `isSecureContext = false` before load to reproduce what a LAN user actually gets, and stub `execCommand` (headless browsers don't reliably provide a real clipboard).

Negative test: restoring the old "never try execCommand" behaviour fails the first test.

## One thing I could not reach, worth a look later

Getting the connect panel to render at all was harder than expected. `/api/players/:id/current-match` reads server status via `getServerStatus(id)`, which defaults to `useCache = false` and queries the server over RCON — so `/api/test/server-status` cannot prime it.

More interesting: the client's online check is

```js
serverStatus === 'online' || serverStatus === 'checking' || serverStatus === 'loading'
```

but that field carries a `ServerStatus`, whose values are `idle | loading | warmup | knife | live | paused | halftime | postgame | queued | error`. **`'online'` and `'checking'` are not among them** — only `'loading'` can ever match on this path. A server sitting in `warmup` would read as offline unless live stats happen to exist.

I could not prove the user-visible consequence without a real server, so I have not touched it — but it lines up uncomfortably well with the #714 report *"Player page says 'Server offline – waiting for recovery' while the server is assigned and online in the overview."* Filed as a note on #714 rather than guessed at here.

## Verification

Full suite **119 passed, 0 failed, 0 skipped**. Ratchet unchanged; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)