### PR TITLE
An assigned server no longer reads as "waiting for assignment"

### DIFF
--- a/client/src/components/team/MatchInfoCard.tsx
+++ b/client/src/components/team/MatchInfoCard.tsx
@@ -173,12 +173,20 @@ export function MatchInfoCard({
       : serverViewerIsTeamMember;
 
   const serverStatus = match.server?.status ?? null;
-  // Only treat explicit "online" (or transitional "checking") as truly online.
-  // However, if we are actively receiving live stats from the MatchZy plugin,
-  // we treat the server as effectively online even if the cached status is
-  // slightly out of date.
-  const isServerOnlineBase =
-    serverStatus === 'online' || serverStatus === 'checking' || serverStatus === 'loading';
+  // `server.status` here is a MatchZy plugin status — idle | loading | warmup |
+  // knife | live | paused | halftime | postgame | queued | error — and
+  // /api/players/:id/current-match only fills it in when the server actually
+  // answered. So any value at all means the server is reachable.
+  //
+  // This used to compare against 'online' and 'checking', which that endpoint
+  // never produces: only 'loading' could ever match. A server sitting in 'idle'
+  // or 'warmup' with a match loaded therefore read as offline, and the page
+  // claimed it was still waiting for a server to be assigned — verified against
+  // a real CS2 server, which reports 'idle' for a freshly loaded match.
+  //
+  // Live stats still count on their own: they only arrive from a server that is
+  // demonstrably talking to us.
+  const isServerOnlineBase = !!serverStatus && serverStatus !== 'error';
   const isServerOnline = isServerOnlineBase || !!liveStats;
   const effectiveServer = isServerOnline ? match.server : null;
 

--- a/tests/ui/server-assigned-panel.spec.ts
+++ b/tests/ui/server-assigned-panel.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+import { ensureSignedIn, signInViaRequest, impersonatePlayer, stopImpersonating } from '../helpers/auth';
+import { setupTournament } from '../helpers/tournamentSetup';
+import { findMatchByTeams } from '../helpers/matches';
+import { actingSteamIdFor } from '../helpers/veto';
+import type { Team } from '../helpers/teams';
+
+/**
+ * A server that is assigned and answering must not read as "not assigned yet".
+ *
+ * `/api/players/:id/current-match` reports `server.status` as a MatchZy plugin
+ * status — idle | loading | warmup | knife | live | ... — and only fills it in
+ * when the server actually answered. The player page used to test that against
+ * `'online' | 'checking' | 'loading'`, two of which this endpoint never
+ * produces, so a server sitting in `idle` or `warmup` read as offline and the
+ * page claimed it was still waiting for a server to be assigned.
+ *
+ * Verified against a real CS2 server, which reports `idle` for a freshly loaded
+ * match. Fake test servers report `idle` too, so this reproduces in CI.
+ *
+ * The match here deliberately has **no live stats**: `isServerOnline` also
+ * accepts live stats, which would mask the bug entirely.
+ *
+ * @tag ui
+ * @tag regression
+ */
+test.describe.serial('Assigned server on the player page', () => {
+  test.setTimeout(120000);
+
+  let team1: Team;
+  let team2: Team;
+
+  test.beforeEach(async ({ page, request }) => {
+    await ensureSignedIn(page);
+    await signInViaRequest(request);
+
+    const setup = await setupTournament(request, {
+      type: 'single_elimination',
+      format: 'bo1',
+      maps: ['de_mirage', 'de_inferno', 'de_ancient', 'de_anubis', 'de_dust2', 'de_vertigo', 'de_nuke'],
+      teamCount: 2,
+      serverCount: 1,
+      prefix: 'assigned',
+    });
+    expect(setup).toBeTruthy();
+    [team1, team2] = [setup!.teams[0], setup!.teams[1]];
+
+    const match = await findMatchByTeams(request, team1.id, team2.id);
+    expect(match?.slug).toBeTruthy();
+
+    const state = await request.post('/api/test/match-state', {
+      data: { slug: match!.slug, serverId: setup!.servers[0].id, status: 'loaded' },
+    });
+    expect(state.ok()).toBe(true);
+  });
+
+  test.afterEach(async ({ page, request }) => {
+    await stopImpersonating(page.request);
+    await stopImpersonating(request);
+  });
+
+  test(
+    'shows the connect panel for a server reporting idle, not "waiting for assignment"',
+    { tag: ['@ui', '@regression'] },
+    async ({ page }) => {
+      const steamId = actingSteamIdFor(team1);
+      expect(await impersonatePlayer(page.request, steamId)).toBe(true);
+
+      await page.goto(`/player/${steamId}`, { waitUntil: 'domcontentloaded' });
+
+      // The connect controls are the visible proof the server is treated as
+      // assigned and reachable.
+      await expect(page.getByRole('button', { name: /Copy Console Command/i })).toBeVisible({
+        timeout: 20000,
+      });
+
+      await expect(page.getByText(/Waiting for Server Assignment/i)).toHaveCount(0);
+    }
+  );
+});


### PR DESCRIPTION
Vikunja #714, the second half. Cryotize, 2025-12-27: *"Player page says 'Server offline – waiting for recovery' while the server is assigned and online in the overview."*

## Cause

`/api/players/:id/current-match` reports `server.status` as a **MatchZy plugin status**:

```
idle | loading | warmup | knife | live | paused | halftime | postgame | queued | error
```

and it only fills that field in when the server actually answered. The player page tested it like this:

```js
serverStatus === 'online' || serverStatus === 'checking' || serverStatus === 'loading'
```

**That endpoint never produces `'online'` or `'checking'`.** Only `'loading'` could ever match. So a server sitting in `idle` or `warmup` — with a match assigned to it — read as offline, and the page told the player it was still waiting for a server.

Confirmed against a real CS2 server on the LAN: a freshly loaded match reports `idle`.

```
server.status: 'idle'
OLD check (online/checking/loading): False
NEW check (non-null, not error):     True
```

Since the endpoint sets a status only when the server answered, any status at all means reachable. Only `'error'` does not.

## Why it survived, and why users called it intermittent

`isServerOnline` also accepts live stats, which masked it whenever they happened to exist.

Before #166 no match reports arrived at all, so live stats came only from webhook events — absent until a match actually started. **The window between assignment and go-live is exactly when a player checks whether they can connect.** That fits the reported "intermittent, fixed by a hard refresh" shape: a refresh after the first round_end would suddenly work.

## It does reproduce in CI

`getServerStatus` short-circuits fake `0.0.0.0` servers with `{ status: 'idle', online: true }` — the very value the old check rejected. So the new test fails against the old check; no real server needed.

This is also why the test in #169 needed a `going_live` event to make the connect panel appear at all. That workaround was this bug, and I mistook it for test setup.

## Verification

- Negative test: restoring the old check fails the new test.
- Real server: values above, read from a live CS2 server with a match loaded.
- Full suite **120 passed, 0 failed, 0 skipped**. Ratchet unchanged; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)