### PR TITLE
Add the missing endpoint behind "Add player to match"

### DIFF
--- a/api/src/routes/rcon.ts
+++ b/api/src/routes/rcon.ts
@@ -743,6 +743,87 @@ router.post('/end-match', async (req: Request, res: Response) => {
 });
 
 /**
+ * POST /api/rcon/:serverId/add-player
+ * Add a backup player or spectator to the match currently set up on a server.
+ *
+ * The admin tools have always called this; it simply did not exist, so every
+ * attempt 404'd and the UI reported "failed to add player to match".
+ *
+ * MatchZy answers over RCON in prose and reports refusals — no match set up,
+ * halftime, already on a team, bad Steam ID — through the *reply text* while
+ * the RCON call itself succeeds. Returning `result.success` alone would tell
+ * the admin the player was added when nothing happened, so the reply is
+ * inspected here.
+ */
+router.post('/:serverId/add-player', async (req: Request, res: Response) => {
+  try {
+    const { serverId } = req.params;
+    const { steamId, team, nickname } = req.body as {
+      steamId?: string;
+      team?: string;
+      nickname?: string;
+    };
+
+    if (!steamId || !team) {
+      return res.status(400).json({
+        success: false,
+        error: 'steamId and team are required',
+      });
+    }
+
+    if (!/^\d{17}$/.test(steamId)) {
+      return res.status(400).json({
+        success: false,
+        error: 'steamId must be a 17-digit Steam64 ID',
+      });
+    }
+
+    const allowedTeams = ['team1', 'team2', 'spec'];
+    if (!allowedTeams.includes(team)) {
+      return res.status(400).json({
+        success: false,
+        error: `team must be one of: ${allowedTeams.join(', ')}`,
+      });
+    }
+
+    // The name is interpolated into a quoted RCON argument, so a quote in it
+    // would end the argument early and corrupt the command.
+    const safeName = (nickname || steamId).replace(/"/g, '').trim() || steamId;
+
+    const result = await rconService.sendCommand(
+      serverId,
+      `matchzy_addplayer ${steamId} ${team} "${safeName}"`
+    );
+
+    if (!result.success) {
+      return res.status(400).json(result);
+    }
+
+    const reply = (result.response || '').trim();
+
+    // MatchZy says "... added to <team> successfully!" on the happy path.
+    if (/successfully/i.test(reply)) {
+      return res.json({ ...result, success: true, message: reply });
+    }
+
+    // Anything else is a refusal it explained in words; pass that on rather
+    // than inventing a generic failure.
+    log.warn('[RCON] matchzy_addplayer refused', { serverId, steamId, team, reply });
+    return res.status(400).json({
+      ...result,
+      success: false,
+      error: reply || 'The server did not confirm the player was added.',
+    });
+  } catch (error) {
+    log.error('Error adding player to match', error as Error);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to add player to match',
+    });
+  }
+});
+
+/**
  * POST /api/rcon/command
  * Execute generic admin commands with parameters
  */

--- a/tests/api/add-player.spec.ts
+++ b/tests/api/add-player.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { setupTestContext } from '../helpers/setup';
+import { createTestServer, deleteServer } from '../helpers/servers';
+
+/**
+ * Adding a backup player or spectator to a live match.
+ *
+ * The admin tools have always POSTed to /api/rcon/:serverId/add-player. The
+ * route did not exist, so every attempt 404'd and the UI reported "failed to
+ * add player to match" — the reported bug, and not only for spectators.
+ *
+ * MatchZy reports refusals (no match set up, halftime, already on a team, bad
+ * Steam ID) in the *reply text* while the RCON call itself succeeds, so the
+ * route has to read the reply. A fake test server answers "fake_response",
+ * which is exactly an unconfirmed add — so the refusal path is what CI can
+ * check. The happy path needs a real CS2 server.
+ *
+ * @tag api
+ * @tag rcon
+ * @tag regression
+ */
+
+const VALID_STEAM_ID = '76561198000000042';
+
+async function addPlayer(
+  request: APIRequestContext,
+  serverId: string,
+  body: Record<string, unknown>
+) {
+  return request.post(`/api/rcon/${serverId}/add-player`, { data: body });
+}
+
+test.describe.serial('Add player to match', () => {
+  let serverId: string;
+
+  test.beforeEach(async ({ page, request }) => {
+    await setupTestContext(page, request);
+    const server = await createTestServer(request, 'addplayer');
+    expect(server).toBeTruthy();
+    serverId = server!.id;
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (serverId) await deleteServer(request, serverId);
+  });
+
+  test(
+    'the endpoint exists at all',
+    { tag: ['@api', '@rcon', '@regression'] },
+    async ({ request }) => {
+      const res = await addPlayer(request, serverId, {
+        steamId: VALID_STEAM_ID,
+        team: 'spec',
+        nickname: 'Caster',
+      });
+
+      // The whole bug: this used to be 404, which the UI showed as
+      // "failed to add player to match".
+      expect(res.status(), 'route must be mounted').not.toBe(404);
+    }
+  );
+
+  test(
+    'does not claim success when the server never confirmed',
+    { tag: ['@api', '@rcon', '@regression'] },
+    async ({ request }) => {
+      const res = await addPlayer(request, serverId, {
+        steamId: VALID_STEAM_ID,
+        team: 'spec',
+        nickname: 'Caster',
+      });
+
+      // A fake server answers without MatchZy's "successfully" confirmation.
+      // Reporting success off `result.success` alone would tell an admin the
+      // spectator was added when nothing happened.
+      expect(res.status()).toBe(400);
+      const body = (await res.json()) as { success: boolean; error?: string };
+      expect(body.success).toBe(false);
+      expect(body.error, 'should pass on what the server actually said').toBeTruthy();
+    }
+  );
+
+  test(
+    'rejects a malformed Steam ID and an unknown team',
+    { tag: ['@api', '@rcon'] },
+    async ({ request }) => {
+      const badId = await addPlayer(request, serverId, { steamId: 'not-a-steamid', team: 'spec' });
+      expect(badId.status()).toBe(400);
+      expect(((await badId.json()) as { error: string }).error).toMatch(/17-digit/i);
+
+      const badTeam = await addPlayer(request, serverId, {
+        steamId: VALID_STEAM_ID,
+        team: 'team3',
+      });
+      expect(badTeam.status()).toBe(400);
+      expect(((await badTeam.json()) as { error: string }).error).toMatch(/team1, team2, spec/);
+
+      const missing = await addPlayer(request, serverId, { team: 'spec' });
+      expect(missing.status()).toBe(400);
+    }
+  );
+});


### PR DESCRIPTION
Vikunja #730. Discord, 2026-01-05, mAa4a: *"how can I add spectators to the server, because from match page it shows 'failed to add player to match'?"* Nobody answered at the time.

## Cause

`AddBackupPlayer.tsx` POSTs to `/api/rcon/:serverId/add-player`. **That route does not exist.** Every attempt 404'd, the client's `catch` fired, and the user saw the generic message.

It isn't a spectator problem — adding a backup player to either team fails identically. The reporter happened to be adding a caster.

## Reading MatchZy's answer properly

`matchzy_addplayer` replies in prose, and reports refusals through the *reply text* while the RCON call itself reports success:

- `No match is setup!`
- `Cannot add players during halftime.`
- `Failed to add player X to team2. They may already be on a team or you provided an invalid Steam ID.`

Returning `result.success` alone would have told an admin the spectator was added when nothing happened — the same class of bug as #151. The route inspects the reply and passes MatchZy's own explanation back, so an admin sees *why*.

Quotes are stripped from the nickname, since it goes into a quoted RCON argument.

## Verified on a real CS2 server

With a match loaded on the LAN server:

| call | result |
|---|---|
| `spec` | `Player Caster One added to spec successfully!` |
| `team1` | `Player Backup Guy added to team1 successfully!` |
| same player again | **400** — `Failed to add player Backup Guy to team2. They may already be on a team...` |

## CI coverage

Three tests: the route is mounted (this is the bug — it used to be 404), the refusal path does not report success, and input validation for Steam ID and team.

The happy path needs a real server: a fake `0.0.0.0` server answers `"fake_response"`, which is precisely an unconfirmed add — so CI exercises the refusal branch by construction, which is the branch worth guarding anyway.

Full suite **122 passed, 0 failed, 0 skipped**. Ratchet unchanged; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)