### PR TITLE
Track a possible IP ban whenever the server is reachable

### DIFF
--- a/api/src/services/rconService.ts
+++ b/api/src/services/rconService.ts
@@ -381,17 +381,20 @@ export class RconService {
       const serverReachable = (lowerMessage.includes('authentication') || lowerMessage === 'authentication error') && !isNetworkError;
       
       if (lowerMessage.includes('authentication') || lowerMessage === 'authentication error') {
-        // Only track as potential IP ban if server is reachable (responded to us)
-        // AND the GameDig query succeeded.
+        // Track a potential IP ban whenever the server is reachable, whatever
+        // the GameDig query said.
         //
-        // NOTE: this used to also allow 'unknown', but that was dead — the
-        // query above always resolves to 'online' or 'offline' before we get
-        // here, so 'unknown' never survives. Behaviour is unchanged by dropping
-        // it. Whether it *should* be permissive is a separate question: the
-        // query failing is explicitly treated as non-blocking above ("server
-        // might still be online with RCON access"), yet a failed query stops
-        // ban tracking even when the server just answered us.
-        if (serverReachable && serverQueryStatus === 'online') {
+        // A server that answers RCON with an auth error has demonstrably just
+        // talked to us, so a failed game-port query tells us nothing about
+        // whether we are banned — and the query is explicitly treated as
+        // non-blocking above ("server might still be online with RCON
+        // access"). Requiring `serverQueryStatus === 'online'` here therefore
+        // dropped exactly the case worth catching: a server that stops
+        // answering queries because our IP is banned.
+        //
+        // The other auth-error path in this file has always keyed off
+        // `serverReachable` alone; this makes the two agree.
+        if (serverReachable) {
           this.recordAuthError(serverId, true);
           const isBanned = this.isLikelyIpBanned(serverId);
           


### PR DESCRIPTION
Vikunja #765, per your call: key ban tracking off `serverReachable` alone.

## What changed

Potential-IP-ban tracking ran only when the GameDig query had *also* succeeded:

```js
if (serverReachable && serverQueryStatus === 'online') {
```

The condition used to allow `'unknown'` as well, but that was dead code — the query always resolves to `online` or `offline` first — so the permissive intent never took effect.

A server that answers RCON with an auth error has demonstrably just talked to us, so a failed game-port query tells us nothing about whether we're banned. The surrounding code already says as much ("Query failure is non-blocking - server might still be online with RCON access"), and **the other auth-error path in this same file has always keyed off `serverReachable` alone.** This makes the two agree.

## No test, and why

Fake `0.0.0.0` servers short-circuit before any auth error can happen, so the only way to produce one is a real CS2 server with a wrong password. Verified there instead.

## What the real-server check turned up

Worth knowing, and **not caused by this change** — I'd rather flag it than let it look fixed:

Repeated bad-password attempts report `Authentication error` **once**, then `invalid_argument` on every retry. Since `clearAuthErrors` fires on anything that isn't an auth error, the counter resets — and `isLikelyIpBanned` wants *three* auth errors within 30s. It cannot fire that way.

I checked whether the server had actually banned us, rather than assuming: the correct password worked immediately afterwards, so **no ban** — `invalid_argument` is just the RCON client's second-attempt behaviour.

That leaves an open question I have not tried to answer here: a genuine IP ban may well make the server stop answering altogether, which produces a network error, sets `serverReachable` false, and clears tracking. If so, the three-auth-errors heuristic may rest on an assumption that does not hold, and the detection would need rethinking rather than adjusting. Filed on #765 rather than guessed at.

This change is still right on its own terms — it removes a condition that could only ever suppress detection, and makes the two paths consistent.

## Verification

Full suite **125 passed, 0 failed, 0 skipped**. Ratchet unchanged; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)