### PR TITLE
Warn when a player ends up on two teams of one tournament

### DIFF
--- a/api/src/routes/teams.ts
+++ b/api/src/routes/teams.ts
@@ -2,6 +2,10 @@ import { Router, Request, Response } from 'express';
 import { teamService } from '../services/teamService';
 import { CreateTeamInput, UpdateTeamInput } from '../types/team.types';
 import { requireAuth } from '../middleware/auth';
+import {
+  findDuplicateTournamentMemberships,
+  describeDuplicateMemberships,
+} from '../utils/duplicateTeamMembership';
 
 const router = Router();
 
@@ -90,10 +94,15 @@ router.post('/', async (req: Request, res: Response) => {
     const input = body as CreateTeamInput;
     const team = await teamService.createTeam(input, upsert);
 
+    const duplicates = await findDuplicateTournamentMemberships(team.id, team.players ?? []);
+
     return res.status(upsert ? 200 : 201).json({
       success: true,
       message: upsert ? `Team '${team.id}' created or updated` : `Team '${team.id}' created`,
       team,
+      ...(duplicates.length > 0
+        ? { warnings: describeDuplicateMemberships(duplicates), duplicateMemberships: duplicates }
+        : {}),
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
@@ -115,10 +124,18 @@ router.put('/:id', async (req: Request, res: Response) => {
 
     const team = await teamService.updateTeam(id, input);
 
+    // Admins are allowed to put a player on two teams of one tournament, but
+    // it silently dead-ends the veto for that player, so say so at the moment
+    // it happens rather than leaving it to be discovered mid-match.
+    const duplicates = await findDuplicateTournamentMemberships(id, team.players ?? []);
+
     return res.json({
       success: true,
       message: `Team '${id}' updated`,
       team,
+      ...(duplicates.length > 0
+        ? { warnings: describeDuplicateMemberships(duplicates), duplicateMemberships: duplicates }
+        : {}),
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';

--- a/api/src/utils/duplicateTeamMembership.ts
+++ b/api/src/utils/duplicateTeamMembership.ts
@@ -1,0 +1,102 @@
+/**
+ * Detecting a player who sits on two teams of the same tournament.
+ *
+ * This state is reachable and it dead-ends the veto: `resolveViewerTeamForMatch`
+ * returns `'both'`, the player cannot act for either side, and the only way out
+ * is an admin removing them from one team. Nothing surfaced it until the veto
+ * refused to move.
+ *
+ * Team rosters are admin-only, so this warns rather than blocks — an admin may
+ * have a reason, and taking the decision away from them was explicitly not
+ * wanted. The point is that they find out when they do it, not during a veto.
+ */
+
+import { db } from '../config/database';
+import { log } from '../utils/logger';
+import type { Player } from '../types/team.types';
+
+export interface DuplicateMembership {
+  steamId: string;
+  name: string;
+  /** Other teams in this tournament that also list the player. */
+  otherTeams: Array<{ id: string; name: string }>;
+}
+
+function parseRoster(players: string | null | undefined): Player[] {
+  if (!players) return [];
+  try {
+    const parsed = JSON.parse(players);
+    return Array.isArray(parsed) ? (parsed as Player[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Which players on `teamId` also appear on another team of the current
+ * tournament.
+ *
+ * Returns an empty list when there is no tournament, when this team is not in
+ * it, or when nothing overlaps — a team outside the tournament cannot create
+ * the veto conflict this guards against.
+ */
+export async function findDuplicateTournamentMemberships(
+  teamId: string,
+  players: Array<{ steamId: string; name?: string }>
+): Promise<DuplicateMembership[]> {
+  if (players.length === 0) return [];
+
+  try {
+    const tournament = await db.queryOneAsync<{ team_ids: string | null }>(
+      'SELECT team_ids FROM tournament WHERE id = 1'
+    );
+    if (!tournament?.team_ids) return [];
+
+    const teamIds: string[] = JSON.parse(tournament.team_ids);
+    if (!Array.isArray(teamIds) || !teamIds.includes(teamId)) return [];
+
+    const otherIds = teamIds.filter((id) => id !== teamId);
+    if (otherIds.length === 0) return [];
+
+    const rows = await db.queryAsync<{ id: string; name: string; players: string | null }>(
+      `SELECT id, name, players FROM teams WHERE id IN (${otherIds.map(() => '?').join(', ')})`,
+      otherIds
+    );
+
+    const byPlayer = new Map<string, DuplicateMembership>();
+
+    for (const row of rows) {
+      const roster = new Set(parseRoster(row.players).map((p) => p.steamId));
+      for (const player of players) {
+        if (!roster.has(player.steamId)) continue;
+
+        const existing = byPlayer.get(player.steamId);
+        const entry = { id: row.id, name: row.name };
+        if (existing) {
+          existing.otherTeams.push(entry);
+        } else {
+          byPlayer.set(player.steamId, {
+            steamId: player.steamId,
+            name: player.name || player.steamId,
+            otherTeams: [entry],
+          });
+        }
+      }
+    }
+
+    return [...byPlayer.values()];
+  } catch (error) {
+    // A warning is a nicety; never fail the save because it could not be built.
+    log.warn('Failed to check for duplicate tournament team memberships', { teamId, error });
+    return [];
+  }
+}
+
+/** One human-readable line per affected player, for the admin UI. */
+export function describeDuplicateMemberships(duplicates: DuplicateMembership[]): string[] {
+  return duplicates.map(
+    (d) =>
+      `${d.name} is also on ${d.otherTeams.map((t) => t.name).join(', ')} in this tournament. ` +
+      `A player on two teams cannot pick maps in the veto for either side.`
+  );
+}

--- a/client/src/components/modals/TeamModal.tsx
+++ b/client/src/components/modals/TeamModal.tsx
@@ -343,24 +343,37 @@ export default function TeamModal({ open, team, onClose, onSave }: TeamModalProp
       };
 
       let newTeamId: string | undefined;
+      // The API flags players who now sit on two teams of the same tournament.
+      // It is allowed — an admin may mean it — but it dead-ends the veto for
+      // that player, so surface it here instead of at match time.
+      let warnings: string[] = [];
+
       if (isEditing) {
-        await api.put(`/api/teams/${team.id}`, {
-          name: payload.name,
-          tag: payload.tag,
-          discordRoleId: undefined, // Discord notifications not yet implemented
-          players: payload.players,
-        });
+        const response = await api.put<{ success: boolean; warnings?: string[] }>(
+          `/api/teams/${team.id}`,
+          {
+            name: payload.name,
+            tag: payload.tag,
+            discordRoleId: undefined, // Discord notifications not yet implemented
+            players: payload.players,
+          }
+        );
+        warnings = response.warnings ?? [];
         showSuccess(t('teamModal.success.teamUpdated'));
       } else {
-        const response = await api.post<{ success: boolean; team: Team }>(
+        const response = await api.post<{ success: boolean; team: Team; warnings?: string[] }>(
           '/api/teams?upsert=true',
           payload
         );
         if (response.success && response.team) {
           newTeamId = response.team.id;
         }
+        warnings = response.warnings ?? [];
         showSuccess(t('teamModal.success.teamCreated'));
       }
+
+      // After the success toast, so the warning is the message left on screen.
+      warnings.forEach((warning) => showWarning(warning));
 
       onSave(newTeamId);
       onClose();

--- a/tests/api/duplicate-team-membership.spec.ts
+++ b/tests/api/duplicate-team-membership.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { setupTestContext } from '../helpers/setup';
+import { setupTournament } from '../helpers/tournamentSetup';
+import type { Team } from '../helpers/teams';
+
+/**
+ * A player on two teams of one tournament dead-ends the veto.
+ *
+ * `resolveViewerTeamForMatch` returns `'both'`, the player cannot act for
+ * either side, and the only way out is an admin removing them from a team.
+ * Nothing surfaced that until the veto refused to move.
+ *
+ * Team rosters are admin-only — there is no player-facing way to join a team —
+ * so this warns rather than blocks. An admin may mean it; they just should not
+ * find out during a match.
+ *
+ * @tag api
+ * @tag teams
+ */
+
+async function updateRoster(
+  request: APIRequestContext,
+  teamId: string,
+  players: Array<{ steamId: string; name: string }>
+) {
+  const res = await request.put(`/api/teams/${teamId}`, { data: { players } });
+  expect(res.ok(), `team update failed: ${await res.text()}`).toBe(true);
+  return (await res.json()) as { success: boolean; warnings?: string[] };
+}
+
+test.describe.serial('Player on two teams of one tournament', () => {
+  let team1: Team;
+  let team2: Team;
+
+  test.beforeEach(async ({ page, request }) => {
+    await setupTestContext(page, request);
+    const setup = await setupTournament(request, {
+      type: 'single_elimination',
+      format: 'bo1',
+      maps: ['de_mirage', 'de_inferno', 'de_ancient', 'de_anubis', 'de_dust2', 'de_vertigo', 'de_nuke'],
+      teamCount: 2,
+      serverCount: 1,
+      prefix: 'dupe',
+    });
+    expect(setup).toBeTruthy();
+    [team1, team2] = [setup!.teams[0], setup!.teams[1]];
+  });
+
+  test(
+    'warns when a player is added to a second team, without blocking it',
+    { tag: ['@api', '@teams'] },
+    async ({ request }) => {
+      const shared = team1.players[0];
+
+      const body = await updateRoster(request, team2.id, [
+        ...team2.players.map((p) => ({ steamId: p.steamId, name: p.name })),
+        { steamId: shared.steamId, name: shared.name },
+      ]);
+
+      // Allowed — the admin keeps the decision.
+      expect(body.success).toBe(true);
+
+      expect(body.warnings ?? [], 'the admin should be told at the moment they do it').not.toEqual(
+        []
+      );
+      expect(body.warnings!.join(' ')).toContain(team1.name);
+      expect(body.warnings!.join(' ')).toContain('veto');
+    }
+  );
+
+  test(
+    'stays quiet for a roster with no overlap',
+    { tag: ['@api', '@teams'] },
+    async ({ request }) => {
+      // Guards the fix from the lazy version of itself: warning on every save
+      // would pass the test above and mean nothing.
+      const body = await updateRoster(
+        request,
+        team2.id,
+        team2.players.map((p) => ({ steamId: p.steamId, name: p.name }))
+      );
+
+      expect(body.success).toBe(true);
+      expect(body.warnings ?? []).toEqual([]);
+    }
+  );
+});


### PR DESCRIPTION
Vikunja #744, per your revised call: warn the admin, don't block.

## The original premise didn't hold

The report was framed as *"it's not the admin the problem, it's the player with selfregistering"*. That flow doesn't exist:

- `/api/auth/self-register` only creates a **player record** — it never touches teams.
- `api/src/routes/teams.ts` opens with `router.use(requireAuth)`, so every roster write is admin-only.
- Shuffle `register-players` sits after the same guard.
- Outside those, every `teamService` call in a player-facing route is a **read**.

So there is no player-facing way to join a team, and the only actor who can create this state is an admin. That's why this warns instead of blocking — and it lands where you originally landed in the thread: *"Do you think we should make a warning if a player is part of more than one team in a tournament?"*

## Why it's worth warning about

A player on two teams of one tournament **cannot veto for either side**. `resolveViewerTeamForMatch` returns `'both'`, the board deadlocks, and the only way out is an admin removing them from a team. Until now nothing said so until the veto refused to move, mid-match.

The admin now hears it at the moment they do it:

> *Player 1 is also on dupe Team 1 in this tournament. A player on two teams cannot pick maps in the veto for either side.*

## Scope and safety

- Only checks teams **in the current tournament** — a player on two unrelated teams can't produce the conflict.
- **Never fails the save.** A warning that breaks team editing would be worse than no warning, so the check is wrapped and returns empty on error.
- The save still succeeds and returns `success: true`; the warning rides alongside.

## Tests

Two, and the second is the point: it asserts a non-overlapping roster produces **no** warning. Without it, warning on every save would satisfy the first test and mean nothing.

## Verification

Full suite **127 passed, 0 failed, 0 skipped**. Ratchet unchanged; eslint clean.

One note: an unrelated hostname test failed once during this work, immediately after recovering from a Docker Desktop crash, and did not reproduce in isolation or on a clean full run. Flagging it rather than assuming it was nothing — worth a second look if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)