### PR TITLE
Say why admin access was refused

### DIFF
--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1070,7 +1070,12 @@ router.get('/admin-status', async (req: Request, res: Response) => {
  */
 router.get('/admin/me', async (req: Request, res: Response) => {
   if (shouldBlockAdminAsDirectAccess(req)) {
-    return res.json({ authenticated: false });
+    return res.json({
+      authenticated: false,
+      reason: 'direct_access_blocked',
+      message:
+        'Admin access is only allowed through the configured frontend URL. This request did not come through your reverse proxy.',
+    });
   }
 
   const anyReq = req as Request & {
@@ -1163,13 +1168,44 @@ router.get('/admin/me', async (req: Request, res: Response) => {
     }
   }
 
+  // Say *why* admin was refused.
+  //
+  // This used to return a bare `authenticated: false`, and the client silently
+  // redirected to the player profile. Three quite different situations —
+  // nobody is signed in, the Steam ID has no player row, and the player exists
+  // but is not an admin — were indistinguishable from the outside, which is
+  // exactly why the reports of "redirected to my player page even though
+  // is_admin = 1" could never be diagnosed: there was nothing to collect.
+  const resolvedSteamId = steamId ?? cookieSteamId ?? null;
+  let reason: 'not_signed_in' | 'no_player_record' | 'not_admin' = 'not_signed_in';
+  let message = 'You are not signed in.';
+
+  if (resolvedSteamId) {
+    let player = null;
+    try {
+      player = await playerService.getPlayerById(resolvedSteamId);
+    } catch (err) {
+      log.warn('Failed to load player while explaining admin denial', err as Error);
+    }
+
+    if (!player) {
+      reason = 'no_player_record';
+      message = `Signed in as ${resolvedSteamId}, but there is no player with that Steam ID.`;
+    } else {
+      reason = 'not_admin';
+      message = `Signed in as ${player.name || resolvedSteamId} (${resolvedSteamId}), but this account is not an admin.`;
+    }
+  }
+
   log.info('/api/auth/admin/me: unauthenticated admin session', {
     hasIsAuthenticated: !!anyReq.isAuthenticated,
     isAuthenticated: anyReq.isAuthenticated ? anyReq.isAuthenticated() : null,
     hasUser: !!anyReq.user,
     hasCookieSteamId: !!cookieSteamId,
+    resolvedSteamId,
+    reason,
   });
-  return res.json({ authenticated: false });
+  return res.json({ authenticated: false, reason, message });
 });
 
 /**

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,7 +3,7 @@ import { ThemeProvider, CssBaseline, Box } from '@mui/material';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { PageHeaderProvider } from './contexts/PageHeaderContext';
-import { SnackbarProvider } from './contexts/SnackbarContext';
+import { SnackbarProvider, useSnackbar } from './contexts/SnackbarContext';
 import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
 import Teams from './pages/Teams';
@@ -42,8 +42,25 @@ interface ProtectedRouteProps {
 }
 
 function ProtectedRoute({ children, adminOnly = true }: ProtectedRouteProps) {
-  const { isAuthenticated, isLoading, playerSteamId, needsSteamLink } = useAuth();
+  const { isAuthenticated, isLoading, playerSteamId, needsSteamLink, adminDenialMessage } =
+    useAuth();
   const location = useLocation();
+  const { showWarning } = useSnackbar();
+
+  // Being bounced to your own player page when you expected the admin panel is
+  // indistinguishable from the app being broken, and it used to happen in
+  // silence — which is why "it redirects me even though I am an admin" was
+  // never diagnosable. Say what the server said.
+  const willRedirectFromAdminRoute =
+    !isLoading && adminOnly && !isAuthenticated && !!playerSteamId && !!adminDenialMessage;
+
+  React.useEffect(() => {
+    if (willRedirectFromAdminRoute && adminDenialMessage) {
+      showWarning(adminDenialMessage);
+    }
+    // Keyed on the message so a changed reason is shown again, but the same
+    // reason does not re-fire on every render.
+  }, [willRedirectFromAdminRoute, adminDenialMessage, showWarning]);
 
   if (isLoading) {
     return (

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -72,6 +72,15 @@ interface AuthContextType {
    */
   adminProvider: string | null;
   /**
+   * Why admin access was refused, in words, when it was.
+   *
+   * `/api/auth/admin/me` used to answer a bare `authenticated: false`, and the
+   * router then bounced the user to their player page without saying anything.
+   * Reports of "it sends me to my player profile even though I am an admin"
+   * were undiagnosable because nothing was ever shown or collected.
+   */
+  adminDenialMessage: string | null;
+  /**
    * Lightweight profile preview for the current admin provider – used for
    * UI hints like the /connect-steam page.
    */
@@ -116,6 +125,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [adminHasSteamLinked, setAdminHasSteamLinked] = useState(false);
   const [adminProvider, setAdminProvider] = useState<string | null>(null);
+  const [adminDenialMessage, setAdminDenialMessage] = useState<string | null>(null);
   const [adminProfileName, setAdminProfileName] = useState<string | null>(null);
   const [adminProfileAvatarUrl, setAdminProfileAvatarUrl] = useState<string | null>(null);
   const [hasPlayerRecord, setHasPlayerRecord] = useState(false);
@@ -234,9 +244,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             steamId?: string | null;
             provider?: string;
             providerProfile?: { name?: string | null; avatarUrl?: string | null };
+            reason?: string;
+            message?: string;
           } = await response.json();
 
           setIsAdmin(Boolean(data.authenticated));
+          // Keep the explanation only while it is true; a later successful
+          // check must not leave a stale "you are not an admin" behind.
+          setAdminDenialMessage(data.authenticated ? null : data.message ?? null);
           setAdminProvider(data.provider ?? null);
           if (data.authenticated) setHasPlayerRecord(true);
 
@@ -417,6 +432,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         needsSteamLink: isAdmin && !adminHasSteamLinked,
         isLoading,
         adminProvider,
+        adminDenialMessage,
         adminProfileName,
         adminProfileAvatarUrl,
         hasPlayerRecord,

--- a/tests/api/admin-denial-reason.spec.ts
+++ b/tests/api/admin-denial-reason.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { setupTestContext } from '../helpers/setup';
+import { signInViaRequest } from '../helpers/auth';
+
+/**
+ * Why admin access was refused.
+ *
+ * `/api/auth/admin/me` used to answer a bare `{ authenticated: false }`, and
+ * the client then redirected to the player profile without a word. Three quite
+ * different situations — nobody signed in, a Steam ID with no player row, and a
+ * player who simply is not an admin — were indistinguishable from outside.
+ *
+ * That is why the reports of "it sends me to my player page even though
+ * is_admin = 1" were never diagnosable: there was nothing for the affected user
+ * to collect or repeat back. The reason now travels with the response and the
+ * UI shows it.
+ *
+ * @tag api
+ * @tag auth
+ * @tag regression
+ */
+
+async function adminMe(request: APIRequestContext) {
+  const res = await request.get('/api/auth/admin/me');
+  expect(res.ok()).toBe(true);
+  return (await res.json()) as {
+    authenticated: boolean;
+    reason?: string;
+    message?: string;
+  };
+}
+
+test.describe.serial('Admin denial reasons', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await setupTestContext(page, request);
+  });
+
+  test(
+    'an admin is still just authenticated, with no leftover reason',
+    { tag: ['@api', '@auth'] },
+    async ({ request }) => {
+      const body = await adminMe(request);
+      expect(body.authenticated).toBe(true);
+      // A stale explanation on a successful check would be worse than none.
+      expect(body.reason).toBeUndefined();
+    }
+  );
+
+  test(
+    'says so when nobody is signed in',
+    { tag: ['@api', '@auth', '@regression'] },
+    async ({ playwright }) => {
+      // A context with no cookies at all.
+      const anon = await playwright.request.newContext({
+        baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3069',
+      });
+      try {
+        const body = await adminMe(anon);
+        expect(body.authenticated).toBe(false);
+        expect(body.reason).toBe('not_signed_in');
+        expect(body.message).toBeTruthy();
+      } finally {
+        await anon.dispose();
+      }
+    }
+  );
+
+  test(
+    'names the account when it is signed in but not an admin',
+    { tag: ['@api', '@auth', '@regression'] },
+    async ({ playwright, request }) => {
+      const playerSteamId = '76561198000000077';
+
+      // Create the player as an admin, then demote — leaves a real player row
+      // that is not an admin, which is the interesting case.
+      const ctx = await playwright.request.newContext({
+        baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3069',
+      });
+      try {
+        expect(await signInViaRequest(ctx, playerSteamId)).toBe(true);
+
+        const demote = await request.put(`/api/players/${playerSteamId}`, {
+          data: { isAdmin: false },
+        });
+        expect(demote.ok(), `demote failed: ${await demote.text()}`).toBe(true);
+
+        const body = await adminMe(ctx);
+        expect(body.authenticated).toBe(false);
+        expect(body.reason).toBe('not_admin');
+        // The Steam ID is the thing a confused user can actually check against
+        // the players table.
+        expect(body.message).toContain(playerSteamId);
+      } finally {
+        await ctx.dispose();
+      }
+    }
+  );
+});


### PR DESCRIPTION
Vikunja #719, the admin-redirect half — but not the fix you approved, because that one turned out not to exist. Details below.

## The approved plan doesn't survive the code

You chose "support it — build the `auth_identities` backfill". It can't be built, and wouldn't help:

```ts
export type AuthProvider = 'discord' | 'keycloak' | 'github';
```

Rows are written **only** in those three OAuth callbacks. A Steam login never touches the table and never needs to — the Steam ID *is* `players.id`, and both `requireAuth` and `/admin/me` read `players.is_admin` directly. An empty `auth_identities` after migration is expected and harmless for Steam users.

A backfill is also impossible in principle: you cannot invent a Discord user ID for an existing player. That link can only form when the user logs in with that provider, which the callbacks already do.

## My replacement hypothesis was wrong too

`shouldBlockAdminAsDirectAccess` looked exact: it returns `{authenticated:false}` with no explanation, which bounces an `is_admin = 1` user to their player profile and survives cleared cookies, deleted sessions and a restart.

It cannot fire. The container runs **Caddy on :3069 proxying `/api/*` to Node on :3000**, and Caddy sets `X-Forwarded-*`, so `isRequestProxied()` is always true. Tested rather than assumed: with `FRONTEND_BASE_URL` set to a domain and a raw in-container request carrying no forwarded headers, `admin/me` still returned `authenticated: true`.

## So this fixes the reason it was undiagnosable

Two plausible causes ruled out, no logs available, and asking the reporter is off the table. What's left is that **the app tells nobody anything**. Four distinct situations produced one identical silent redirect:

| situation | before | now |
|---|---|---|
| nobody signed in | silent redirect | `not_signed_in` |
| Steam ID with no player row | silent redirect | `no_player_record` |
| player exists, not an admin | silent redirect | `not_admin` |
| direct-access block | silent redirect | `direct_access_blocked` |

The message names the resolved Steam ID — the one thing someone can check against their own `players` table without help:

> *Signed in as Test Admin (76561198000000001), but this account is not an admin.*

**Who gets admin is unchanged.** This only makes the existing decision legible. The next person who hits this can say what it told them, and the answer takes one message instead of a wipe.

## Verification

- Negative test: restoring the bare `{authenticated:false}` fails the tests (`Expected: "not_signed_in", Received: undefined`).
- A test asserts a *successful* check carries no leftover reason — a stale "you are not an admin" would be worse than none.
- Full suite **128 passed, 0 failed, 0 skipped**. Ratchet unchanged; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)