### PR TITLE
Team page follows the roster, not a stale snapshot

### DIFF
--- a/api/src/routes/teamMatch.ts
+++ b/api/src/routes/teamMatch.ts
@@ -322,8 +322,33 @@ router.get('/:teamId/match', async (req: Request, res: Response) => {
     // We intentionally scope this to the team whose page is being viewed
     // (teamId route param), not just "any team in the match", so opponents
     // cannot use the other team's link to see server or veto controls.
+    //
+    // The team's own roster decides this, not the match config. `config` is a
+    // snapshot taken when the match was created, and it goes stale the moment
+    // an admin edits the team — in both directions, both wrong:
+    //
+    //  - someone removed from the roster kept seeing the match server, because
+    //    the snapshot still listed them;
+    //  - someone added after the snapshot could not see their own server,
+    //    which is the reported "the server shows on my player page but not on
+    //    the team page".
+    //
+    // `veto.ts` already resolves membership this way, and for the same reason:
+    // an admin correcting a roster should take effect immediately. The snapshot
+    // is still the fallback for a team row that has no usable roster.
     const viewerSteamId = await getViewerSteamId(req);
-    const playersForThisTeam = isTeam1 ? normalizedTeam1Players : normalizedTeam2Players;
+    const rosterForThisTeam = normalizeConfigPlayers(
+      (() => {
+        try {
+          return team.players ? JSON.parse(team.players) : [];
+        } catch {
+          return [];
+        }
+      })()
+    );
+    const snapshotForThisTeam = isTeam1 ? normalizedTeam1Players : normalizedTeam2Players;
+    const playersForThisTeam =
+      rosterForThisTeam.length > 0 ? rosterForThisTeam : snapshotForThisTeam;
     const viewerIsTeamMember =
       !!viewerSteamId && playersForThisTeam.some((p) => p.steamid === viewerSteamId);
 

--- a/tests/api/team-page-roster.spec.ts
+++ b/tests/api/team-page-roster.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { setupTestContext } from '../helpers/setup';
+import { setupTournament } from '../helpers/tournamentSetup';
+import { findMatchByTeams } from '../helpers/matches';
+import { updateTeam } from '../helpers/teams';
+import { impersonatePlayer, stopImpersonating } from '../helpers/auth';
+import type { Team } from '../helpers/teams';
+
+/**
+ * The team page follows the team's roster, not the match config snapshot.
+ *
+ * `config` is written when the match is created and goes stale the moment an
+ * admin edits the team. Deciding "is this viewer on this team?" from it was
+ * wrong in both directions:
+ *
+ *  - a player removed from the roster kept seeing the match server, because
+ *    the snapshot still listed them;
+ *  - a player added after the snapshot could not see their own server, which
+ *    is the reported "it shows on my player page but not the team page".
+ *
+ * `veto.ts` already resolves membership from the roster for the same reason.
+ *
+ * @tag api
+ * @tag teams
+ * @tag regression
+ */
+
+async function serverVisibleTo(
+  request: APIRequestContext,
+  teamId: string,
+  steamId: string
+): Promise<boolean> {
+  expect(await impersonatePlayer(request, steamId)).toBe(true);
+  try {
+    const res = await request.get(`/api/team/${teamId}/match`);
+    expect(res.ok()).toBe(true);
+    const body = (await res.json()) as { match?: { server?: unknown } };
+    return Boolean(body.match?.server);
+  } finally {
+    await stopImpersonating(request);
+  }
+}
+
+test.describe.serial('Team page membership follows the roster', () => {
+  let team1: Team;
+  let team2: Team;
+
+  test.beforeEach(async ({ page, request }) => {
+    await setupTestContext(page, request);
+
+    const setup = await setupTournament(request, {
+      type: 'single_elimination',
+      format: 'bo1',
+      maps: ['de_mirage', 'de_inferno', 'de_ancient', 'de_anubis', 'de_dust2', 'de_vertigo', 'de_nuke'],
+      teamCount: 2,
+      serverCount: 1,
+      prefix: 'roster',
+    });
+    expect(setup).toBeTruthy();
+    [team1, team2] = [setup!.teams[0], setup!.teams[1]];
+
+    const match = await findMatchByTeams(request, team1.id, team2.id);
+    expect(match?.slug).toBeTruthy();
+
+    const state = await request.post('/api/test/match-state', {
+      data: { slug: match!.slug, serverId: setup!.servers[0].id, status: 'loaded' },
+    });
+    expect(state.ok()).toBe(true);
+  });
+
+  test(
+    'a removed player stops seeing the match server',
+    { tag: ['@api', '@teams', '@regression'] },
+    async ({ request }) => {
+      const removed = team1.players[0];
+
+      expect(
+        await serverVisibleTo(request, team1.id, removed.steamId),
+        'a roster member should see it to begin with'
+      ).toBe(true);
+
+      await updateTeam(request, team1.id, {
+        players: team1.players.slice(1).map((p) => ({ steamId: p.steamId, name: p.name })),
+      });
+
+      expect(
+        await serverVisibleTo(request, team1.id, removed.steamId),
+        'removing someone from the roster should take effect immediately'
+      ).toBe(false);
+    }
+  );
+
+  test(
+    'a player added after the match was created sees the server',
+    { tag: ['@api', '@teams', '@regression'] },
+    async ({ request }) => {
+      const newcomer = { steamId: '76561198000000555', name: 'Newcomer' };
+
+      await updateTeam(request, team1.id, {
+        players: [
+          ...team1.players.map((p) => ({ steamId: p.steamId, name: p.name })),
+          newcomer,
+        ],
+      });
+
+      expect(
+        await serverVisibleTo(request, team1.id, newcomer.steamId),
+        'a current roster member should see their own match server'
+      ).toBe(true);
+    }
+  );
+
+  test(
+    'an opponent still cannot see this team\u2019s server',
+    { tag: ['@api', '@teams', '@security'] },
+    async ({ request }) => {
+      // The whole point of the check; following the roster must not widen it.
+      expect(await serverVisibleTo(request, team1.id, team2.players[0].steamId)).toBe(false);
+    }
+  );
+});


### PR DESCRIPTION
Came out of Vikunja #743. Your call there — *"it's fine for teams to see each other's pages, we just don't need to share the ability to control it"* — is already how it works: the veto authorizes every action by Steam identity, and `serverPassword` on this endpoint is hardcoded `null`. So no restriction is needed, and #743 is closed as working-as-intended.

But checking *how* control is gated turned up a real bug.

## Membership was read from a snapshot

`teamMatch.ts` decided "is this viewer on this team?" from `match.config` — written when the match was created. `veto.ts` deliberately uses the **teams table**, with a comment saying an admin correcting a roster should take effect immediately. The team page never got the same treatment, and was wrong in **both** directions. Reproduced before fixing:

| viewer | on roster? | in snapshot? | saw server |
|---|---|---|---|
| original member | yes | yes | ✅ correct |
| **removed** | **no** | yes (stale) | ❌ **still visible** |
| **newly added** | **yes** | no | ❌ **hidden** |

The last row is a report already on file under #714 — sanpy, 2026-01-06: *"after a manual match is ready, the server appears on the Player page but not the Team page."* The player page resolves identity independently of the snapshot, so the two disagreed. That's the whole symptom.

The middle row is why this is worth doing regardless: someone taken off a roster kept connect details for that team's match. Not credentials — `serverPassword` is `null` here — but host, port and live status.

## Fix

Use the team's own roster, falling back to the snapshot only when the team row has no usable roster. Same rule `veto.ts` already applies, so the two now agree.

## Tests

Three, and the third is the one that matters: **an opponent still cannot see the server.** Following the roster must only *correct* who qualifies, never widen it — without that test, a fix that accidentally let everyone through would pass the other two.

Negative test: restoring the snapshot behaviour fails with *"removing someone from the roster should take effect immediately"*.

## Verification

Full suite **130 passed, 0 failed, 0 skipped**. Ratchet unchanged; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)