### PR TITLE
Say whether the Steam API key works, at boot

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -48,6 +48,7 @@ import { initMatchZyVersionService } from './services/matchzyVersionService';
 import { recoverActiveMatches } from './services/matchRecoveryService';
 import { matchAllocationService } from './services/matchAllocationService';
 import { healthMonitoringService } from './services/healthMonitoringService';
+import { steamService } from './services/steamService';
 import packageJson from '../package.json';
 import { configurePassportAuth, passport } from './config/passport';
 import session from 'express-session';
@@ -504,6 +505,9 @@ process.on('uncaughtException', (err) => {
         recoverActiveMatches().catch((error) => {
           log.warn('Failed to recover active matches on startup', { error });
         }),
+        reportSteamApiKeyStatus().catch((error) => {
+          log.warn('Failed to check the Steam Web API key on startup', { error });
+        }),
       ]).then(() => {
         log.success('[Startup] All startup tasks completed');
         
@@ -567,6 +571,56 @@ process.on('uncaughtException', (err) => {
     process.exit(1);
   }
 })();
+
+/**
+ * Report the state of the Steam Web API key once, at startup.
+ *
+ * The health check already classifies a missing key, a rejected key and an
+ * unreachable Steam, but nothing ran it until something happened to need
+ * Steam — so an operator who started the container with a bad key saw a clean
+ * log and found out much later, if at all. That is the reported problem: a
+ * whole debugging session lost to a fake key, when one line at boot would have
+ * ended it.
+ *
+ * Never fatal. Steam is optional, and Steam being down is not a reason to
+ * refuse to start; the point is to say so plainly.
+ */
+async function reportSteamApiKeyStatus(): Promise<void> {
+  const health = await steamService.checkSteamWebApiHealth({ force: true });
+
+  if (health.ok) {
+    log.success('[Startup] Steam Web API key is valid');
+    return;
+  }
+
+  switch (health.errorType) {
+    case 'not_configured':
+      log.warn(
+        '[Startup] STEAM_API_KEY is not set. Steam features (avatars, name lookups, ' +
+          'Steam sign-in checks) are disabled. Get a key at ' +
+          'https://steamcommunity.com/dev/apikey and set STEAM_API_KEY.'
+      );
+      break;
+    case 'invalid_key':
+      log.error(
+        '[Startup] STEAM_API_KEY was rejected by Steam' +
+          (health.statusCode ? ` (HTTP ${health.statusCode})` : '') +
+          '. The key is set but not valid, so Steam features will fail. ' +
+          'Check it at https://steamcommunity.com/dev/apikey.'
+      );
+      break;
+    case 'unreachable':
+      log.warn(
+        `[Startup] Could not reach the Steam Web API to verify STEAM_API_KEY (${health.error}). ` +
+          'This may be temporary; the key will be re-checked when it is next used.'
+      );
+      break;
+    default:
+      log.warn(
+        `[Startup] STEAM_API_KEY could not be verified: ${health.error ?? 'unknown error'}`
+      );
+  }
+}
 
 async function bootstrapServerWebhooks(): Promise<void> {
   const serverToken = process.env.SERVER_TOKEN;

--- a/tests/api/steam-key-health.spec.ts
+++ b/tests/api/steam-key-health.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { setupTestContext } from '../helpers/setup';
+
+/**
+ * The Steam Web API key is reported at startup.
+ *
+ * The health check has always been able to tell a missing key from a rejected
+ * one from an unreachable Steam — but nothing ran it until something needed
+ * Steam, so an operator who started the container with a bad key saw a clean
+ * log. That cost a reporter a whole debugging session against a fake key.
+ *
+ * Startup logging itself cannot be asserted from here (the process is already
+ * running). What this pins is the classification the startup message is built
+ * from: if `errorType` stops distinguishing these cases, the log line silently
+ * becomes useless.
+ *
+ * @tag api
+ * @tag steam
+ */
+test.describe('Steam Web API key health', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await setupTestContext(page, request);
+  });
+
+  test(
+    'reports a classified state the startup message can be built from',
+    { tag: ['@api', '@steam'] },
+    async ({ request }) => {
+      const res = await request.get('/api/steam/status');
+      expect(res.ok(), `steam status failed: ${await res.text()}`).toBe(true);
+
+      const body = (await res.json()) as {
+        configured?: boolean;
+        valid?: boolean;
+        errorType?: string;
+      };
+
+      // Either it is healthy, or it says which kind of unhealthy — never a
+      // bare failure, which is what made this undiagnosable at startup.
+      if (body.valid) {
+        expect(body.configured).toBe(true);
+        expect(body.errorType).toBeUndefined();
+      } else {
+        expect(
+          ['not_configured', 'invalid_key', 'unreachable', 'unknown'],
+          'an unclassified failure gives the startup log nothing useful to say'
+        ).toContain(body.errorType);
+      }
+    }
+  );
+});


### PR DESCRIPTION
Vikunja #749. tech62, 2026-02-03: *"Add a STEAM_API_KEY check after start the container (show error if steam api key is invalid)."* He'd lost a debugging session to a fake key whose only symptom was that things quietly didn't work.

## What was already there, and what wasn't

`checkSteamWebApiHealth` has always been able to distinguish a missing key, a rejected key, and an unreachable Steam. **Nothing ran it until something happened to need Steam.** So the log was clean at boot regardless, and the first sign of trouble was a feature not working later — or a toast, if you happened to be an admin looking at the right screen.

One line at startup ends that.

## Verified against the real Steam Web API

Not mocked — all three states, by actually changing the key and restarting:

| key | log line |
|---|---|
| valid | `[SUCCESS] [Startup] Steam Web API key is valid` |
| **invalid** | `[ERROR] [Startup] STEAM_API_KEY was rejected by Steam (HTTP 403). The key is set but not valid, so Steam features will fail. Check it at https://steamcommunity.com/dev/apikey.` |
| missing | `[WARN] [Startup] STEAM_API_KEY is not set. Steam features (avatars, name lookups, Steam sign-in checks) are disabled. Get a key at ... and set STEAM_API_KEY.` |

Each says what is wrong, what it costs you, and where to go. `.env` restored afterwards with the real key intact.

**Never fatal.** Steam is optional, and Steam being unreachable is not a reason to refuse to start — an `unreachable` result warns and notes it will be re-checked on next use.

## What the test pins, and why it isn't the log line

The startup log can't be asserted from a test against an already-running process. So the test pins the thing the message is *built from*: that an unhealthy result always carries a classified `errorType`.

That's the failure worth guarding. If `errorType` stops distinguishing these cases, the startup line keeps printing and silently becomes useless — which is exactly the bug being fixed here, one level down.

## Verification

Full suite **131 passed, 0 failed, 0 skipped**. Ratchet unchanged; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)