### PR TITLE
Seed admins from ADMIN_STEAM_IDS so an instance can be recovered

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -49,6 +49,7 @@ import { recoverActiveMatches } from './services/matchRecoveryService';
 import { matchAllocationService } from './services/matchAllocationService';
 import { healthMonitoringService } from './services/healthMonitoringService';
 import { steamService } from './services/steamService';
+import { seedAdminsFromEnv } from './services/adminSeedService';
 import packageJson from '../package.json';
 import { configurePassportAuth, passport } from './config/passport';
 import session from 'express-session';
@@ -507,6 +508,9 @@ process.on('uncaughtException', (err) => {
         }),
         reportSteamApiKeyStatus().catch((error) => {
           log.warn('Failed to check the Steam Web API key on startup', { error });
+        }),
+        seedAdminsFromEnv().catch((error) => {
+          log.warn('Failed to seed admins from ADMIN_STEAM_IDS on startup', { error });
         }),
       ]).then(() => {
         log.success('[Startup] All startup tasks completed');

--- a/api/src/services/adminSeedService.ts
+++ b/api/src/services/adminSeedService.ts
@@ -1,0 +1,83 @@
+/**
+ * Seeding admins from the environment.
+ *
+ * Admin rights are otherwise bootstrapped by "the first player to sign in gets
+ * them", which only works on an empty database: `ensureFirstAdmin` refuses to
+ * promote once more than one player exists. An instance that already has
+ * players and no admin — the state every 1.x upgrade lands in, because the
+ * players table comes across but nothing is marked admin — therefore has *no*
+ * way back in except editing the database by hand. That is why upgraders were
+ * told to wipe.
+ *
+ * `ADMIN_STEAM_IDS` is the way back in. It is applied on every boot, so it also
+ * works as recovery: set it, restart, sign in.
+ *
+ * Additive only. It never demotes anyone, because the env var is a recovery
+ * hatch rather than the source of truth for who administers a running
+ * instance — an operator who removes an ID from it has almost certainly not
+ * asked for that person to lose access mid-tournament.
+ */
+
+import { log } from '../utils/logger';
+import { playerService } from './playerService';
+import { parseAdminSteamIds } from '../utils/adminSteamIds';
+
+/**
+ * Ensure every Steam ID in `ADMIN_STEAM_IDS` exists as a player and is an admin.
+ *
+ * Never throws: a malformed value should not stop the server from starting,
+ * it should say so and carry on.
+ */
+export async function seedAdminsFromEnv(): Promise<void> {
+  const raw = process.env.ADMIN_STEAM_IDS;
+  const { valid, invalid } = parseAdminSteamIds(raw);
+
+  if (invalid.length > 0) {
+    log.warn(
+      `[Startup] Ignoring ${invalid.length} malformed entr${invalid.length === 1 ? 'y' : 'ies'} ` +
+        `in ADMIN_STEAM_IDS (expected 17-digit Steam64 IDs): ${invalid.join(', ')}`
+    );
+  }
+
+  if (valid.length === 0) {
+    if (raw && raw.trim().length > 0) {
+      log.warn('[Startup] ADMIN_STEAM_IDS is set but contained no usable Steam64 IDs');
+    }
+    return;
+  }
+
+  const promoted: string[] = [];
+  const alreadyAdmin: string[] = [];
+
+  for (const steamId of valid) {
+    try {
+      const existing = await playerService.getPlayerById(steamId);
+
+      if (existing?.isAdmin) {
+        alreadyAdmin.push(steamId);
+        continue;
+      }
+
+      if (!existing) {
+        // Named after the Steam ID; a real name arrives on first Steam login.
+        await playerService.getOrCreatePlayer(steamId, steamId);
+      }
+
+      await playerService.updatePlayer(steamId, { isAdmin: true });
+      promoted.push(steamId);
+    } catch (error) {
+      log.error(`[Startup] Failed to seed admin ${steamId} from ADMIN_STEAM_IDS`, error as Error);
+    }
+  }
+
+  if (promoted.length > 0) {
+    log.success(
+      `[Startup] Granted admin from ADMIN_STEAM_IDS to ${promoted.length} player(s): ${promoted.join(', ')}`
+    );
+  }
+  if (alreadyAdmin.length > 0) {
+    log.info(
+      `[Startup] ADMIN_STEAM_IDS: ${alreadyAdmin.length} player(s) already admin: ${alreadyAdmin.join(', ')}`
+    );
+  }
+}

--- a/api/src/utils/adminSteamIds.ts
+++ b/api/src/utils/adminSteamIds.ts
@@ -1,0 +1,34 @@
+/**
+ * Parsing the `ADMIN_STEAM_IDS` environment variable.
+ *
+ * Kept free of database imports so it can be tested as the pure function it
+ * is — importing the seeding service pulls in a connection pool.
+ */
+
+/** Steam64 IDs are 17 digits; anything else is a typo, not an ID. */
+const STEAM64_PATTERN = /^\d{17}$/;
+
+export function parseAdminSteamIds(raw: string | undefined): {
+  valid: string[];
+  invalid: string[];
+} {
+  if (!raw || raw.trim().length === 0) return { valid: [], invalid: [] };
+
+  const tokens = raw
+    .split(/[\s,;]+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+
+  const valid: string[] = [];
+  const invalid: string[] = [];
+
+  for (const token of tokens) {
+    if (STEAM64_PATTERN.test(token)) {
+      if (!valid.includes(token)) valid.push(token);
+    } else {
+      invalid.push(token);
+    }
+  }
+
+  return { valid, invalid };
+}

--- a/example.env
+++ b/example.env
@@ -78,6 +78,20 @@ AUTH_STEAM_ENABLED=true
 # Required: Steam Web API key (obtain from https://steamcommunity.com/dev/apikey)
 STEAM_API_KEY=your-steam-web-api-key
 
+# Optional: Steam64 IDs that should always have admin rights.
+#
+# Applied on every start: each ID is created as a player if missing and marked
+# admin. Additive — it never removes admin from anyone else.
+#
+# Without this, admin is bootstrapped by "the first player to sign in gets it",
+# which only works on an empty database. An instance that already has players
+# but no admin (for example after upgrading from 1.x, where the players table
+# comes across but nobody is marked admin) has no other way in short of editing
+# the database. Set this, restart, sign in.
+#
+# Comma- or space-separated, 17-digit Steam64 IDs:
+# ADMIN_STEAM_IDS=76561198000000001,76561198000000002
+
 ## Keycloak (OIDC) – optional
 
 # Example (uncomment and fill in to enable Keycloak SSO for admins):

--- a/tests/api/admin-seed.spec.ts
+++ b/tests/api/admin-seed.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { parseAdminSteamIds } from '../../api/src/utils/adminSteamIds';
+
+/**
+ * Parsing ADMIN_STEAM_IDS.
+ *
+ * The seeding itself runs at startup against the real database, so it cannot
+ * be driven from here — but the parsing is where this can quietly go wrong. A
+ * typo'd ID that is silently accepted would create a junk player row and grant
+ * admin to nobody, which is worse than refusing it out loud.
+ *
+ * @tag api
+ * @tag auth
+ */
+test.describe('ADMIN_STEAM_IDS parsing', () => {
+  test('accepts a list and rejects anything that is not a Steam64 ID', () => {
+    const { valid, invalid } = parseAdminSteamIds(
+      '76561198000000001, 76561198000000002 76561198000000003;not-an-id 123'
+    );
+
+    expect(valid).toEqual([
+      '76561198000000001',
+      '76561198000000002',
+      '76561198000000003',
+    ]);
+    // Refused loudly rather than turned into a junk player row.
+    expect(invalid).toEqual(['not-an-id', '123']);
+  });
+
+  test('de-duplicates, so a repeated ID is not promoted twice', () => {
+    const { valid } = parseAdminSteamIds('76561198000000001 76561198000000001');
+    expect(valid).toEqual(['76561198000000001']);
+  });
+
+  test('treats unset and empty as "nothing to do", not as an error', () => {
+    expect(parseAdminSteamIds(undefined)).toEqual({ valid: [], invalid: [] });
+    expect(parseAdminSteamIds('   ')).toEqual({ valid: [], invalid: [] });
+  });
+});


### PR DESCRIPTION
Vikunja #742. tech62, on the 2.0.0 upgrade: *"Ouch, not possible to evitate the wipe? (or mention the steamID admin in the .env)"*

## Why "the first player to sign in becomes admin" doesn't save you

`ensureFirstAdmin` **refuses once more than one player exists**:

```js
if (totalPlayers > 1) { /* skip auto-admin promotion */ }
```

So it only works on an empty database. An instance that already has players but no admin has **no way back in except editing the database by hand** — which is precisely the state a 1.x upgrade lands in: the players table comes across, nobody is marked admin.

That is why upgraders were told to wipe, and it's the same thread as #719. Reproduced before building anything: two players, zero admins, restart → still zero admins.

## The way back in

`ADMIN_STEAM_IDS` is applied on **every** boot, so it doubles as recovery rather than being a one-shot install step: set it, restart, sign in.

**Additive only — it never demotes.** The variable is a recovery hatch, not the roster of who administers a running instance. An operator trimming the list has almost certainly not asked for that person to lose access mid-tournament, and silently revoking admin because someone edited an env var is a nasty way to find that out.

## Verified against a real database, not mocked

| case | result |
|---|---|
| existing player | promoted, name intact (`Imported One`) |
| unknown Steam ID | player created, then promoted |
| **third player** | **left alone** — additive confirmed |
| `bogus-id` | refused out loud, not turned into a junk row |
| second boot | reports *"already admin"* instead of rewriting |

```
[WARN]    Ignoring 1 malformed entry in ADMIN_STEAM_IDS (expected 17-digit Steam64 IDs): bogus-id
[SUCCESS] Granted admin from ADMIN_STEAM_IDS to 2 player(s): ...
```

`.env` restored afterwards with the real key intact.

## Notes

Parsing lives in its own util with **no database import**, so it can be tested as the pure function it is — importing the service pulls in a connection pool, which had my first version spinning one up per test.

Rebased onto #179; both startup checks coexist and were confirmed running together after the rebase.

Documented in `example.env` with the reasoning, since the value of this is entirely in someone finding it when locked out.

## Verification

Full suite **137 passed, 0 failed, 0 skipped**. Ratchet unchanged; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)