### PR TITLE
docs(api): generate the endpoint reference from the routers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Typecheck (ratchet)
         run: yarn typecheck:ratchet
 
+      # docs/API-REFERENCE.md is generated from the routers. This fails when a
+      # route is added, removed or has its auth changed without regenerating,
+      # which is the only thing that keeps the reference honest.
+      - name: API reference is current
+        run: yarn docs:api:check
+
   e2e:
     name: E2E tests
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ See screenshots in the docs: https://docs.sivert.io/docs/mat/user/screenshots
 
 **For Developers:**
 - [Using the API from a bot or script](docs/API.md)
+- [Complete API reference](docs/API-REFERENCE.md) (generated)
 - [Contributing Guide](.github/CONTRIBUTING.md)
 - [Architecture](https://docs.sivert.io/docs/mat/developer/architecture)
 - [Testing](https://docs.sivert.io/docs/mat/developer/testing)

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -18,32 +18,7 @@ import { serverService } from './services/serverService';
 import { rconService } from './services/rconService';
 import { settingsService } from './services/settingsService';
 import { serverInitializationService } from './services/serverInitializationService';
-import serverRoutes from './routes/servers';
-import serverStatusRoutes from './routes/serverStatus';
-import serverBootstrapRoutes from './routes/serverBootstrap';
-import teamRoutes from './routes/teams';
-import rconRoutes from './routes/rcon';
-import matchRoutes from './routes/matches';
-import eventRoutes from './routes/events';
-import steamRoutes from './routes/steam';
-import tournamentRoutes from './routes/tournament';
-import demoRoutes from './routes/demos';
-import teamMatchRoutes from './routes/teamMatch';
-import teamStatsRoutes from './routes/teamStats';
-import logsRoutes from './routes/logs';
-import vetoRoutes from './routes/veto';
-import settingsRoutes from './routes/settings';
-import mapsRoutes from './routes/maps';
-import mapPoolsRoutes from './routes/mapPools';
-import recoveryRoutes from './routes/recovery';
-import generationRoutes from './routes/generation';
-import templatesRoutes from './routes/templates';
-import manualMatchTemplatesRoutes from './routes/manualMatchTemplates';
-import playersRoutes from './routes/players';
-import eloTemplatesRoutes from './routes/eloTemplates';
-import testRoutes from './routes/test';
-import authRoutes from './routes/auth';
-import matchzyRoutes from './routes/matchzy';
+import { routeTable } from './routes/routeTable';
 import { initMatchZyVersionService } from './services/matchzyVersionService';
 import { recoverActiveMatches } from './services/matchRecoveryService';
 import { matchAllocationService } from './services/matchAllocationService';
@@ -369,33 +344,14 @@ app.get('/api/health/fleet', async (_req: Request, res: Response) => {
   });
 });
 
-// API Routes
-app.use('/api/servers', serverBootstrapRoutes);
-app.use('/api/servers', serverRoutes);
-app.use('/api/servers', serverStatusRoutes); // Mount status routes under /api/servers
-app.use('/api/teams', teamRoutes);
-app.use('/api/rcon', rconRoutes);
-app.use('/api/matches', matchRoutes);
-app.use('/api/events', eventRoutes);
-app.use('/api/steam', steamRoutes);
-app.use('/api/tournament', tournamentRoutes);
-app.use('/api/demos', demoRoutes);
-app.use('/api/logs', logsRoutes);
-app.use('/api/team', teamMatchRoutes); // Public team match data
-app.use('/api/team', teamStatsRoutes); // Public team stats/history
-app.use('/api/veto', vetoRoutes); // Map veto system
-app.use('/api/settings', settingsRoutes);
-app.use('/api/maps', mapsRoutes);
-app.use('/api/map-pools', mapPoolsRoutes);
-app.use('/api/templates', templatesRoutes); // Tournament templates
-app.use('/api/manual-match-templates', manualMatchTemplatesRoutes); // Manual match templates
-app.use('/api/recovery', recoveryRoutes); // Match recovery endpoints
-app.use('/api/players', playersRoutes); // Player management
-app.use('/api/elo-templates', eloTemplatesRoutes); // ELO calculation templates
-app.use('/api/generation', generationRoutes); // Shared name/code generators (e.g. team names)
-app.use('/api/test', testRoutes); // Test utilities (log markers, etc.)
-app.use('/api/auth', authRoutes); // Authentication (Steam, Keycloak, Discord)
-app.use('/api/matchzy', matchzyRoutes); // MatchZy Enhanced version info
+// API Routes.
+//
+// The mount table lives in routes/routeTable.ts so that the reference
+// generator can read it without starting a server. Order is significant —
+// see the note there.
+for (const { prefix, router } of routeTable) {
+  app.use(prefix, router);
+}
 
 // Serve frontend at /app (built client lives under api/public)
 const publicPath = path.join(__dirname, '..', 'public');

--- a/api/src/routes/routeTable.ts
+++ b/api/src/routes/routeTable.ts
@@ -1,0 +1,217 @@
+/**
+ * Where every router is mounted.
+ *
+ * This used to be a run of `app.use(...)` calls in `index.ts`. It is a list
+ * now so that something other than the running server can read it — namely
+ * `scripts/generate-api-reference.ts`, which walks these routers to produce
+ * the complete endpoint reference in `docs/API-REFERENCE.md`.
+ *
+ * That matters because the alternative is documenting 180-odd endpoints by
+ * hand, which is how both of the previous attempts drifted: `docs/API.md`
+ * describes the endpoints a bot would want and no more, and the OpenAPI
+ * annotations cover about a third of the surface, with `rcon`, `players`,
+ * `servers`, `matches`, `teams` and `veto` carrying none at all.
+ *
+ * **Order is significant.** Express matches in registration order, and several
+ * prefixes are shared by more than one router — `/api/servers` has three and
+ * `/api/team` has two. Keep the entries in the order they should be matched.
+ */
+
+import type { Router } from 'express';
+
+import serverBootstrapRoutes from './serverBootstrap';
+import serverRoutes from './servers';
+import serverStatusRoutes from './serverStatus';
+import teamRoutes from './teams';
+import rconRoutes from './rcon';
+import matchRoutes from './matches';
+import eventRoutes from './events';
+import steamRoutes from './steam';
+import tournamentRoutes from './tournament';
+import demoRoutes from './demos';
+import logsRoutes from './logs';
+import teamMatchRoutes from './teamMatch';
+import teamStatsRoutes from './teamStats';
+import vetoRoutes from './veto';
+import settingsRoutes from './settings';
+import mapsRoutes from './maps';
+import mapPoolsRoutes from './mapPools';
+import templatesRoutes from './templates';
+import manualMatchTemplatesRoutes from './manualMatchTemplates';
+import recoveryRoutes from './recovery';
+import playersRoutes from './players';
+import eloTemplatesRoutes from './eloTemplates';
+import generationRoutes from './generation';
+import testRoutes from './test';
+import authRoutes from './auth';
+import matchzyRoutes from './matchzy';
+
+export interface MountedRouter {
+  /** Path prefix the router is mounted under. */
+  prefix: string;
+  router: Router;
+  /** Group heading in the generated reference. */
+  title: string;
+  /** One line on what this group is for. */
+  description: string;
+}
+
+export const routeTable: MountedRouter[] = [
+  {
+    prefix: '/api/servers',
+    router: serverBootstrapRoutes,
+    title: 'Server bootstrap',
+    description: 'Self-registration for a CS2 server coming online.',
+  },
+  {
+    prefix: '/api/servers',
+    router: serverRoutes,
+    title: 'Servers',
+    description: 'The CS2 server fleet — add, edit, enable, remove.',
+  },
+  {
+    prefix: '/api/servers',
+    router: serverStatusRoutes,
+    title: 'Server status',
+    description: 'Liveness, connectivity and CS2 update state per server.',
+  },
+  {
+    prefix: '/api/teams',
+    router: teamRoutes,
+    title: 'Teams',
+    description: 'Team roster CRUD, including batch create and delete.',
+  },
+  {
+    prefix: '/api/rcon',
+    router: rconRoutes,
+    title: 'RCON',
+    description: 'Direct server control — pause, say, end match, raw commands.',
+  },
+  {
+    prefix: '/api/matches',
+    router: matchRoutes,
+    title: 'Matches',
+    description: 'Create, load, restart and cancel matches; read match state.',
+  },
+  {
+    prefix: '/api/events',
+    router: eventRoutes,
+    title: 'Events',
+    description: 'MatchZy webhooks in, and the recorded event log out.',
+  },
+  {
+    prefix: '/api/steam',
+    router: steamRoutes,
+    title: 'Steam',
+    description: 'Steam Web API lookups (profiles, avatars, key health).',
+  },
+  {
+    prefix: '/api/tournament',
+    router: tournamentRoutes,
+    title: 'Tournament',
+    description: 'The tournament itself — setup, bracket, rounds, standings.',
+  },
+  {
+    prefix: '/api/demos',
+    router: demoRoutes,
+    title: 'Demos',
+    description: 'Demo upload from the game server, and download.',
+  },
+  {
+    prefix: '/api/logs',
+    router: logsRoutes,
+    title: 'Logs',
+    description: 'Server-side event logs.',
+  },
+  {
+    prefix: '/api/team',
+    router: teamMatchRoutes,
+    title: 'Team match view',
+    description: "A team's current match, oriented to that team. Public.",
+  },
+  {
+    prefix: '/api/team',
+    router: teamStatsRoutes,
+    title: 'Team stats',
+    description: 'Past results and aggregates for a team. Public.',
+  },
+  {
+    prefix: '/api/veto',
+    router: vetoRoutes,
+    title: 'Veto',
+    description: 'Map veto state and actions.',
+  },
+  {
+    prefix: '/api/settings',
+    router: settingsRoutes,
+    title: 'Settings',
+    description: 'Instance-wide settings.',
+  },
+  {
+    prefix: '/api/maps',
+    router: mapsRoutes,
+    title: 'Maps',
+    description: 'The map catalogue.',
+  },
+  {
+    prefix: '/api/map-pools',
+    router: mapPoolsRoutes,
+    title: 'Map pools',
+    description: 'Named sets of maps for veto and match config.',
+  },
+  {
+    prefix: '/api/templates',
+    router: templatesRoutes,
+    title: 'Tournament templates',
+    description: 'Saved tournament configurations.',
+  },
+  {
+    prefix: '/api/manual-match-templates',
+    router: manualMatchTemplatesRoutes,
+    title: 'Manual match templates',
+    description: 'Saved configurations for one-off matches.',
+  },
+  {
+    prefix: '/api/recovery',
+    router: recoveryRoutes,
+    title: 'Recovery',
+    description: 'Reconcile matches after an API restart or a server going away.',
+  },
+  {
+    prefix: '/api/players',
+    router: playersRoutes,
+    title: 'Players',
+    description: 'Player records, ratings, match history and profiles.',
+  },
+  {
+    prefix: '/api/elo-templates',
+    router: eloTemplatesRoutes,
+    title: 'ELO templates',
+    description: 'Rating calculation presets.',
+  },
+  {
+    prefix: '/api/generation',
+    router: generationRoutes,
+    title: 'Generation',
+    description: 'Shared generators, e.g. random team names.',
+  },
+  {
+    prefix: '/api/test',
+    router: testRoutes,
+    title: 'Test helpers',
+    description:
+      'E2E helpers. Disabled in production unless ENABLE_TEST_ENDPOINTS is set.',
+  },
+  {
+    prefix: '/api/auth',
+    router: authRoutes,
+    title: 'Auth',
+    description: 'Sign-in flows, admin identity, impersonation.',
+  },
+  {
+    prefix: '/api/matchzy',
+    router: matchzyRoutes,
+    title: 'MatchZy',
+    description: 'MatchZy Enhanced version information.',
+  },
+];

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,0 +1,409 @@
+<!--
+  GENERATED FILE — DO NOT EDIT BY HAND.
+
+  Produced by scripts/generate-api-reference.ts, which walks the real Express
+  routers listed in api/src/routes/routeTable.ts. Regenerate with:
+
+      yarn docs:api
+
+  CI fails if this file does not match the routers (yarn docs:api --check).
+-->
+
+# API reference
+
+Every endpoint this API serves — 187 of them, 138 behind auth —
+read directly from the routers rather than written down, so it cannot drift.
+
+For *how* to authenticate a bot or script, and a task-oriented tour of the
+endpoints worth using, see [API.md](API.md). This file is the index.
+
+## Reading the Auth column
+
+| Value | Meaning |
+| --- | --- |
+| `public` | No credential needed |
+| `admin` | An admin session, or a service token (`API_TOKENS`; `API_TOKENS_READONLY` for `GET`) |
+| `server token` | `X-MatchZy-Token` — for CS2 game servers, not for bots |
+
+`public` means the middleware requires nothing. A few of these still resolve
+the caller's identity from a cookie and change what they return, or reject the
+action further in — map veto is the notable one, since actions are attributed
+to a player. Read the handler before assuming an endpoint is anonymous.
+
+## Endpoints
+
+### Health and docs
+
+Served by the app itself rather than a router.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api-docs.json` | public |
+| `GET` | `/` | public |
+| `GET` | `/health` | public |
+| `GET` | `/api/health/fleet` | public |
+
+### Server bootstrap
+
+Self-registration for a CS2 server coming online.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/servers/:id/bootstrap` | server token |
+
+### Servers
+
+The CS2 server fleet — add, edit, enable, remove.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/servers` | admin |
+| `POST` | `/api/servers/batch` | admin |
+| `PATCH` | `/api/servers/batch` | admin |
+| `GET` | `/api/servers/:id` | admin |
+| `POST` | `/api/servers` | admin |
+| `PUT` | `/api/servers/:id` | admin |
+| `PATCH` | `/api/servers/:id` | admin |
+| `DELETE` | `/api/servers/:id` | admin |
+| `POST` | `/api/servers/bulk-delete` | admin |
+| `POST` | `/api/servers/:id/enable` | admin |
+| `POST` | `/api/servers/:id/disable` | admin |
+| `POST` | `/api/servers/:id/reset-initialization` | admin |
+| `POST` | `/api/servers/reset-all-initialization` | admin |
+
+### Server status
+
+Liveness, connectivity and CS2 update state per server.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/servers/:id/status` | admin |
+
+### Teams
+
+Team roster CRUD, including batch create and delete.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/teams` | admin |
+| `GET` | `/api/teams/:id` | admin |
+| `POST` | `/api/teams` | admin |
+| `PUT` | `/api/teams/:id` | admin |
+| `PATCH` | `/api/teams/batch` | admin |
+| `DELETE` | `/api/teams/:id` | admin |
+| `POST` | `/api/teams/bulk-delete` | admin |
+
+### RCON
+
+Direct server control — pause, say, end match, raw commands.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/rcon/test/:serverId` | admin |
+| `GET` | `/api/rcon/test` | admin |
+| `POST` | `/api/rcon/test-connection` | admin |
+| `POST` | `/api/rcon/practice-mode` | admin |
+| `POST` | `/api/rcon/start-match` | admin |
+| `POST` | `/api/rcon/change-map` | admin |
+| `POST` | `/api/rcon/pause-match` | admin |
+| `POST` | `/api/rcon/unpause-match` | admin |
+| `POST` | `/api/rcon/force-pause` | admin |
+| `POST` | `/api/rcon/force-unpause` | admin |
+| `POST` | `/api/rcon/restart-match` | admin |
+| `POST` | `/api/rcon/end-warmup` | admin |
+| `POST` | `/api/rcon/reload-admins` | admin |
+| `POST` | `/api/rcon/say` | admin |
+| `POST` | `/api/rcon/broadcast` | admin |
+| `POST` | `/api/rcon/swap-teams` | admin |
+| `POST` | `/api/rcon/restore-backup` | admin |
+| `POST` | `/api/rcon/skip-veto` | admin |
+| `POST` | `/api/rcon/restart-round` | admin |
+| `POST` | `/api/rcon/add-time` | admin |
+| `POST` | `/api/rcon/end-match` | admin |
+| `POST` | `/api/rcon/:serverId/add-player` | admin |
+| `POST` | `/api/rcon/command` | admin |
+
+### Matches
+
+Create, load, restart and cancel matches; read match state.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/matches/:slug.json` | public |
+| `DELETE` | `/api/matches/:slug` | admin |
+| `POST` | `/api/matches/bulk-delete` | admin |
+| `GET` | `/api/matches` | public |
+| `GET` | `/api/matches/:slug` | public |
+| `POST` | `/api/matches` | admin |
+| `POST` | `/api/matches/:slug/load` | admin |
+| `POST` | `/api/matches/:slug/restart` | admin |
+| `POST` | `/api/matches/:slug/reallocate` | admin |
+| `PATCH` | `/api/matches/:slug/status` | admin |
+| `POST` | `/api/matches/:slug/force-cancel` | admin |
+| `DELETE` | `/api/matches/:slug` | admin |
+
+### Events
+
+MatchZy webhooks in, and the recorded event log out.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/events/test` | public |
+| `POST` | `/api/events` | public |
+| `POST` | `/api/events/report` | server token |
+| `POST` | `/api/events/:matchSlugOrServerId` | public |
+| `GET` | `/api/events/connections/:matchSlug` | public |
+| `GET` | `/api/events/live/:matchSlug` | public |
+| `GET` | `/api/events/server/:serverId` | admin |
+| `GET` | `/api/events/:matchSlug` | admin |
+
+### Steam
+
+Steam Web API lookups (profiles, avatars, key health).
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/steam/status` | admin |
+| `POST` | `/api/steam/resolve` | admin |
+| `GET` | `/api/steam/player/:steamId` | admin |
+| `GET` | `/api/steam/workshop-map` | admin |
+
+### Tournament
+
+The tournament itself — setup, bracket, rounds, standings.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/tournament/:id/leaderboard` | public |
+| `GET` | `/api/tournament/allocation-status` | public |
+| `GET` | `/api/tournament` | admin |
+| `POST` | `/api/tournament` | admin |
+| `PUT` | `/api/tournament` | admin |
+| `DELETE` | `/api/tournament` | admin |
+| `GET` | `/api/tournament/bracket` | admin |
+| `POST` | `/api/tournament/bracket/regenerate` | admin |
+| `POST` | `/api/tournament/reset` | admin |
+| `GET` | `/api/tournament/server-availability` | admin |
+| `POST` | `/api/tournament/start` | admin |
+| `POST` | `/api/tournament/restart` | admin |
+| `POST` | `/api/tournament/wipe-database` | admin |
+| `POST` | `/api/tournament/wipe-table/:table` | admin |
+| `POST` | `/api/tournament/dev/reset-simulation-state` | admin |
+| `POST` | `/api/tournament/shuffle` | admin |
+| `POST` | `/api/tournament/:id/manual-matches` | admin |
+| `POST` | `/api/tournament/:id/register-players` | admin |
+| `PUT` | `/api/tournament/:id/set-players` | admin |
+| `GET` | `/api/tournament/:id/players` | admin |
+| `GET` | `/api/tournament/:id/leaderboard` | admin |
+| `GET` | `/api/tournament/:id/round-status` | admin |
+| `POST` | `/api/tournament/:id/generate-round` | admin |
+| `GET` | `/api/tournament/:id/elo-template` | admin |
+| `PUT` | `/api/tournament/:id/elo-template` | admin |
+| `POST` | `/api/tournament/:id/check-completion` | admin |
+
+### Demos
+
+Demo upload from the game server, and download.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `POST` | `/api/demos/:matchSlug/upload` | server token |
+| `GET` | `/api/demos/:matchSlug/download/:mapNumber?` | public |
+| `GET` | `/api/demos/:matchSlug/status` | admin |
+| `GET` | `/api/demos/:matchSlug/info` | admin |
+
+### Logs
+
+Server-side event logs.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/logs` | admin |
+
+### Team match view
+
+A team's current match, oriented to that team. Public.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/team/:teamId/match` | public |
+
+### Team stats
+
+Past results and aggregates for a team. Public.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/team/:teamId/history` | public |
+| `GET` | `/api/team/:teamId/stats` | public |
+
+### Veto
+
+Map veto state and actions.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/veto/:matchSlug` | public |
+| `POST` | `/api/veto/:matchSlug/action` | public |
+| `POST` | `/api/veto/:matchSlug/reset` | admin |
+
+### Settings
+
+Instance-wide settings.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/settings/version` | public |
+| `GET` | `/api/settings` | admin |
+| `PUT` | `/api/settings` | admin |
+
+### Maps
+
+The map catalogue.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/maps` | admin |
+| `GET` | `/api/maps/:id` | admin |
+| `POST` | `/api/maps` | admin |
+| `PUT` | `/api/maps/:id` | admin |
+| `PATCH` | `/api/maps/:id` | admin |
+| `POST` | `/api/maps/:id/upload-image` | admin |
+| `POST` | `/api/maps/sync` | admin |
+| `DELETE` | `/api/maps/:id` | admin |
+
+### Map pools
+
+Named sets of maps for veto and match config.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/map-pools` | admin |
+| `GET` | `/api/map-pools/:id` | admin |
+| `POST` | `/api/map-pools` | admin |
+| `PUT` | `/api/map-pools/:id/enable` | admin |
+| `PUT` | `/api/map-pools/:id/disable` | admin |
+| `PUT` | `/api/map-pools/:id/set-default` | admin |
+| `PUT` | `/api/map-pools/:id` | admin |
+| `DELETE` | `/api/map-pools/:id` | admin |
+
+### Tournament templates
+
+Saved tournament configurations.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/templates` | admin |
+| `POST` | `/api/templates` | admin |
+| `GET` | `/api/templates/:id` | admin |
+| `PUT` | `/api/templates/:id` | admin |
+| `DELETE` | `/api/templates/:id` | admin |
+
+### Manual match templates
+
+Saved configurations for one-off matches.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/manual-match-templates` | admin |
+| `POST` | `/api/manual-match-templates` | admin |
+
+### Recovery
+
+Reconcile matches after an API restart or a server going away.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `POST` | `/api/recovery/recover` | admin |
+| `POST` | `/api/recovery/replay/:matchSlug` | admin |
+
+### Players
+
+Player records, ratings, match history and profiles.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/players/find` | public |
+| `GET` | `/api/players/public-selection` | public |
+| `GET` | `/api/players/selection` | admin |
+| `GET` | `/api/players/:playerId/team` | public |
+| `GET` | `/api/players/me/match-status` | public |
+| `GET` | `/api/players/:playerId/current-match` | public |
+| `GET` | `/api/players/:playerId/summary` | public |
+| `GET` | `/api/players/:playerId/avatar.svg` | public |
+| `GET` | `/api/players/:playerId` | public |
+| `GET` | `/api/players/:playerId/rating-history` | public |
+| `GET` | `/api/players/:playerId/matches` | public |
+| `GET` | `/api/players` | admin |
+| `POST` | `/api/players` | admin |
+| `POST` | `/api/players/bulk-import` | admin |
+| `POST` | `/api/players/bulk-delete` | admin |
+| `PUT` | `/api/players/:playerId` | admin |
+| `DELETE` | `/api/players/:playerId` | admin |
+
+### ELO templates
+
+Rating calculation presets.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/elo-templates` | admin |
+| `GET` | `/api/elo-templates/:id` | admin |
+| `POST` | `/api/elo-templates` | admin |
+| `PUT` | `/api/elo-templates/:id` | admin |
+| `DELETE` | `/api/elo-templates/:id` | admin |
+
+### Generation
+
+Shared generators, e.g. random team names.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/generation/team-name` | admin |
+
+### Test helpers
+
+E2E helpers. Disabled in production unless ENABLE_TEST_ENDPOINTS is set.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `POST` | `/api/test/marker` | admin |
+| `POST` | `/api/test/reset-database` | admin |
+| `POST` | `/api/test/server-status` | admin |
+| `POST` | `/api/test/match-state` | admin |
+| `POST` | `/api/test/match-report` | admin |
+| `POST` | `/api/test/login-admin` | public |
+| `POST` | `/api/test/login-player` | public |
+
+### Auth
+
+Sign-in flows, admin identity, impersonation.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/auth/steam` | public |
+| `GET` | `/api/auth/steam/callback` | public |
+| `POST` | `/api/auth/logout` | public |
+| `GET` | `/api/auth/keycloak` | public |
+| `GET` | `/api/auth/keycloak/callback` | public |
+| `GET` | `/api/auth/discord` | public |
+| `GET` | `/api/auth/discord/callback` | public |
+| `GET` | `/api/auth/github` | public |
+| `GET` | `/api/auth/github/callback` | public |
+| `GET` | `/api/auth/providers` | public |
+| `GET` | `/api/auth/me` | public |
+| `POST` | `/api/auth/self-register` | public |
+| `GET` | `/api/auth/admin-status` | public |
+| `GET` | `/api/auth/admin/me` | public |
+| `POST` | `/api/auth/admin/logout` | public |
+| `GET` | `/api/auth/impersonate` | admin |
+| `POST` | `/api/auth/impersonate` | admin |
+| `POST` | `/api/auth/impersonate/stop` | admin |
+
+### MatchZy
+
+MatchZy Enhanced version information.
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/api/matchzy/latest-version` | public |

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,9 +4,14 @@ MAT's dashboard is a normal client of its own HTTP API. Anything the dashboard
 can do, another program can do — run a tournament from Discord, post scoreboards
 to a channel, wire match results into something else.
 
-This document covers how a machine authenticates, and what is on the other side
-once it does. The generated endpoint reference lives at `/api-docs` on a running
-instance (`/api-docs.json` for the raw OpenAPI spec).
+This document covers how a machine authenticates, and a task-oriented tour of
+the endpoints worth using. For the **complete** list — every endpoint and what
+guards it, generated from the routers themselves — see
+[API-REFERENCE.md](API-REFERENCE.md).
+
+A Swagger UI is also served at `/api-docs` on a running instance
+(`/api-docs.json` for the raw spec), but its annotations cover only part of the
+surface; the generated reference is the one that is complete.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
         "typecheck": "tsc -p api/tsconfig.json --noEmit && tsc -p client/tsconfig.json --noEmit",
         "typecheck:ratchet": "node scripts/typecheck-ratchet.mjs",
         "typecheck:baseline": "node scripts/typecheck-ratchet.mjs --update",
+    "docs:api": "tsx scripts/generate-api-reference.ts",
+    "docs:api:check": "tsx scripts/generate-api-reference.ts --check",
         "db": "docker ps --format '{{.Names}}' | grep -q '^matchzy-postgres$' && echo '\u2705 PostgreSQL container is already running' || (docker ps -a --format '{{.Names}}' | grep -q '^matchzy-postgres$' && (docker start matchzy-postgres && echo '\u2705 Started existing PostgreSQL container') || (docker run -d --name matchzy-postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=matchzy_tournament -p 5432:5432 postgres:16-alpine && echo '\u2705 Created and started PostgreSQL container'))",
         "db:stop": "docker stop matchzy-postgres 2>/dev/null && echo '\u2705 Stopped PostgreSQL container' || echo '\u26a0\ufe0f  PostgreSQL container not running'",
         "db:restart": "yarn db:stop && sleep 1 && yarn db",

--- a/scripts/generate-api-reference.ts
+++ b/scripts/generate-api-reference.ts
@@ -1,0 +1,261 @@
+/**
+ * Generate docs/API-REFERENCE.md from the actual Express routers.
+ *
+ * Hand-written endpoint lists rot. `docs/API.md` covers the endpoints a bot
+ * would want and stops there; the OpenAPI annotations cover about a third of
+ * the surface. Neither tells you what is actually mounted, and neither
+ * complains when a route is added.
+ *
+ * This reads the routers themselves. Every router carries a `stack` of layers:
+ * a layer with a `route` is an endpoint, and a layer without one is middleware
+ * applied to everything registered after it. That is exactly enough to recover
+ * both the path list and which of them are guarded, because `requireAuth` and
+ * `validateServerToken` appear in the stack under their own function names —
+ * whether applied per-route (`router.get(path, requireAuth, handler)`) or to a
+ * whole router (`router.use(requireAuth)`).
+ *
+ * Usage:
+ *   yarn docs:api           # write docs/API-REFERENCE.md
+ *   yarn docs:api --check   # exit 1 if the file is stale (used by CI)
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { routeTable } from '../api/src/routes/routeTable';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const OUTPUT = path.join(REPO_ROOT, 'docs', 'API-REFERENCE.md');
+const INDEX_TS = path.join(REPO_ROOT, 'api', 'src', 'index.ts');
+
+/** Middleware we recognise, and what it means for a caller. */
+const GUARDS: Record<string, string> = {
+  requireAuth: 'admin',
+  validateServerToken: 'server token',
+};
+
+interface Endpoint {
+  method: string;
+  path: string;
+  guards: string[];
+}
+
+interface Group {
+  title: string;
+  prefix: string;
+  description: string;
+  endpoints: Endpoint[];
+}
+
+// Express layer internals. Typed loosely on purpose: this is a private shape,
+// and pinning it exactly would only turn an Express upgrade into a type error
+// instead of the runtime check below, which explains itself far better.
+interface Layer {
+  name?: string;
+  route?: {
+    path: string | string[];
+    methods: Record<string, boolean>;
+    stack: Array<{ name?: string }>;
+  };
+}
+
+/**
+ * Walk one router in registration order.
+ *
+ * Router-level middleware (`router.use(requireAuth)`) applies to everything
+ * registered *after* it, so guards accumulate as we go rather than being read
+ * per route. Several routers rely on that — `teams`, `settings` and `servers`
+ * guard the whole file with a single `use`, while `matches` guards route by
+ * route, and `tournament` and `players` do both, switching partway down.
+ */
+function walkRouter(router: unknown): Endpoint[] {
+  const stack = (router as { stack?: Layer[] }).stack;
+
+  if (!Array.isArray(stack)) {
+    throw new Error(
+      'Router has no `stack` array. Express changed its internals, so this ' +
+        'generator can no longer see the routes and would silently emit an ' +
+        'empty reference. Fix the walk in scripts/generate-api-reference.ts.'
+    );
+  }
+
+  const endpoints: Endpoint[] = [];
+  const routerGuards: string[] = [];
+
+  for (const layer of stack) {
+    if (!layer.route) {
+      // Middleware applied to the rest of this router.
+      const guard = layer.name && GUARDS[layer.name];
+      if (guard && !routerGuards.includes(guard)) routerGuards.push(guard);
+      continue;
+    }
+
+    const routeGuards = [...routerGuards];
+    for (const handler of layer.route.stack) {
+      const guard = handler.name && GUARDS[handler.name];
+      if (guard && !routeGuards.includes(guard)) routeGuards.push(guard);
+    }
+
+    const paths = Array.isArray(layer.route.path) ? layer.route.path : [layer.route.path];
+    for (const routePath of paths) {
+      for (const method of Object.keys(layer.route.methods)) {
+        endpoints.push({
+          method: method.toUpperCase(),
+          path: routePath,
+          guards: routeGuards,
+        });
+      }
+    }
+  }
+
+  return endpoints;
+}
+
+/**
+ * Routes declared on the app rather than on a router — `/health` and friends.
+ *
+ * These are read out of index.ts as text. They are a handful of top-level
+ * calls with literal paths, and lifting them into a router purely so this
+ * script could import them would be tail-wagging-dog; reading them keeps them
+ * in the reference and keeps the drift visible.
+ */
+function appLevelEndpoints(): Endpoint[] {
+  const source = fs.readFileSync(INDEX_TS, 'utf8');
+  const pattern = /^app\.(get|post|put|patch|delete)\(\s*'([^']+)'/gm;
+  const endpoints: Endpoint[] = [];
+
+  for (const match of source.matchAll(pattern)) {
+    const [, method, routePath] = match;
+    // The SPA catch-all is not an API endpoint.
+    if (routePath.startsWith('/app')) continue;
+    endpoints.push({ method: method.toUpperCase(), path: routePath, guards: [] });
+  }
+
+  return endpoints;
+}
+
+function describeGuards(guards: string[]): string {
+  if (guards.length === 0) return 'public';
+  return guards.join(' + ');
+}
+
+function renderGroup(group: Group): string {
+  if (group.endpoints.length === 0) return '';
+
+  const rows = group.endpoints
+    .map((e) => {
+      // `/` as a router path means the prefix itself — except in the
+      // app-level group, which has no prefix, where `/` is the real path.
+      const full = e.path === '/' ? group.prefix || '/' : `${group.prefix}${e.path}`;
+      return `| \`${e.method}\` | \`${full}\` | ${describeGuards(e.guards)} |`;
+    })
+    .join('\n');
+
+  return [
+    `### ${group.title}`,
+    '',
+    group.description,
+    '',
+    '| Method | Path | Auth |',
+    '| --- | --- | --- |',
+    rows,
+    '',
+  ].join('\n');
+}
+
+function render(groups: Group[], total: number): string {
+  const guarded = groups
+    .flatMap((g) => g.endpoints)
+    .filter((e) => e.guards.length > 0).length;
+
+  return `<!--
+  GENERATED FILE — DO NOT EDIT BY HAND.
+
+  Produced by scripts/generate-api-reference.ts, which walks the real Express
+  routers listed in api/src/routes/routeTable.ts. Regenerate with:
+
+      yarn docs:api
+
+  CI fails if this file does not match the routers (yarn docs:api --check).
+-->
+
+# API reference
+
+Every endpoint this API serves — ${total} of them, ${guarded} behind auth —
+read directly from the routers rather than written down, so it cannot drift.
+
+For *how* to authenticate a bot or script, and a task-oriented tour of the
+endpoints worth using, see [API.md](API.md). This file is the index.
+
+## Reading the Auth column
+
+| Value | Meaning |
+| --- | --- |
+| \`public\` | No credential needed |
+| \`admin\` | An admin session, or a service token (\`API_TOKENS\`; \`API_TOKENS_READONLY\` for \`GET\`) |
+| \`server token\` | \`X-MatchZy-Token\` — for CS2 game servers, not for bots |
+
+\`public\` means the middleware requires nothing. A few of these still resolve
+the caller's identity from a cookie and change what they return, or reject the
+action further in — map veto is the notable one, since actions are attributed
+to a player. Read the handler before assuming an endpoint is anonymous.
+
+## Endpoints
+
+${groups.map(renderGroup).filter(Boolean).join('\n')}`;
+}
+
+function main(): void {
+  const check = process.argv.includes('--check');
+
+  const groups: Group[] = [
+    {
+      title: 'Health and docs',
+      prefix: '',
+      description: 'Served by the app itself rather than a router.',
+      endpoints: appLevelEndpoints(),
+    },
+    ...routeTable.map((mount) => ({
+      title: mount.title,
+      prefix: mount.prefix,
+      description: mount.description,
+      endpoints: walkRouter(mount.router),
+    })),
+  ];
+
+  const total = groups.reduce((n, g) => n + g.endpoints.length, 0);
+
+  if (total < 100) {
+    throw new Error(
+      `Only found ${total} endpoints, which is far fewer than this API has. ` +
+        'Refusing to write a reference that is almost certainly wrong.'
+    );
+  }
+
+  const output = render(groups, total);
+  const existing = fs.existsSync(OUTPUT) ? fs.readFileSync(OUTPUT, 'utf8') : null;
+
+  if (check) {
+    if (existing === output) {
+      console.log(`docs/API-REFERENCE.md is up to date (${total} endpoints).`);
+      return;
+    }
+    console.error(
+      'docs/API-REFERENCE.md is out of date with the routers.\n' +
+        'Run `yarn docs:api` and commit the result.'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, output);
+  console.log(
+    `Wrote docs/API-REFERENCE.md — ${total} endpoints across ${groups.length} groups.`
+  );
+}
+
+main();
+// Importing the routers pulls in services that hold timers and a database
+// pool, so the process would otherwise sit there with nothing to do.
+process.exit(process.exitCode ?? 0);


### PR DESCRIPTION
## Why

There was no complete list of what this API serves.

| Source | Endpoints covered | of 187 |
| --- | --- | --- |
| `docs/API.md` | 34 | curated for bot use |
| OpenAPI annotations (`/api-docs`) | 55 | `rcon`, `players`, `servers`, `matches`, `teams`, `veto` have **none** |

Both are hand-maintained, so both drift, and neither notices when a route is added. Annotating the remaining ~130 by hand would just produce a third list to keep in sync.

## What

`docs/API-REFERENCE.md` is now generated by walking the real Express routers — **187 endpoints, 138 behind auth**, grouped, with the guard on each.

Every router exposes a `stack` of layers: a layer with a `route` is an endpoint, one without is middleware applied to everything registered after it. That recovers the paths and — because `requireAuth` and `validateServerToken` appear in the stack under their own function names — which endpoints are guarded, whether applied per-route or to a whole router via `router.use`. `tournament` and `players` do both, switching partway down the file; the walk handles it the way Express does, in order.

```bash
yarn docs:api          # regenerate
yarn docs:api:check    # fail if stale
```

CI runs the check next to the typecheck ratchet. **That gate is the point** — a generated file nobody verifies is just a stale file with better provenance. Verified by adding a route and watching `--check` exit 1, then reverting.

Two guards against the walk silently succeeding at nothing: it throws if a router has no `stack` (Express changing its internals), and refuses to write a reference with fewer than 100 endpoints.

### Refactor

The mount table moves from a run of `app.use(...)` calls in `index.ts` to `api/src/routes/routeTable.ts`, so the generator can read it without starting a server. Order is preserved and commented — `/api/servers` has three routers, `/api/team` has two.

## ⚠️ Surfaced by the generated table

`POST /api/events` and `POST /api/events/:matchSlugOrServerId` have **no auth middleware and no in-handler token check**, while [`index.ts:251`](api/src/index.ts#L251) advertises the webhook as `"server token required"`. Only `/api/events/report` actually validates one — these are the game-event ingest paths.

Left alone here; changing auth on a live ingest path is not a docs change. Worth its own PR.

## Testing

- App boots with the refactored mount table; every prefix verified to route, and the Auth column spot-checked against live responses (`/api/teams` → 401 unauthenticated, `/api/matchzy/latest-version` → 200 public, matching the table).
- 62 API tests pass: `service-token`, `teams`, `players`, `servers`, `veto`, `end-match`, `match-phase`, `impersonation`, `admin-denial-reason`, `public-pages`.
- Typecheck ratchet: no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)