### PR TITLE
docs(api): complete the OpenAPI spec, and commit it for client generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,11 @@ jobs:
       - name: Typecheck (ratchet)
         run: yarn typecheck:ratchet
 
-      # docs/API-REFERENCE.md is generated from the routers. This fails when a
-      # route is added, removed or has its auth changed without regenerating,
-      # which is the only thing that keeps the reference honest.
-      - name: API reference is current
+      # docs/API-REFERENCE.md and docs/openapi.json are generated from the
+      # routers. This fails when a route is added, removed or has its auth
+      # changed without regenerating — the only thing keeping them honest, and
+      # openapi.json is what people outside this repo generate clients from.
+      - name: API docs are current
         run: yarn docs:api:check
 
   e2e:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See screenshots in the docs: https://docs.sivert.io/docs/mat/user/screenshots
 
 **For Developers:**
 - [Using the API from a bot or script](docs/API.md)
-- [Complete API reference](docs/API-REFERENCE.md) (generated)
+- [Complete API reference](docs/API-REFERENCE.md) and [OpenAPI spec](docs/openapi.json) (both generated)
 - [Contributing Guide](.github/CONTRIBUTING.md)
 - [Architecture](https://docs.sivert.io/docs/mat/developer/architecture)
 - [Testing](https://docs.sivert.io/docs/mat/developer/testing)

--- a/api/src/config/swagger.ts
+++ b/api/src/config/swagger.ts
@@ -1,4 +1,14 @@
 import swaggerJsdoc from 'swagger-jsdoc';
+import path from 'path';
+import {
+  collectRouterGroups,
+  pathParams,
+  toOpenApiPath,
+  type Guard,
+} from '../utils/routeIntrospection';
+
+/** Absolute path to `api/src`, so the jsdoc globs do not depend on cwd. */
+const API_SRC = path.resolve(__dirname, '..');
 
 const swaggerServerUrl =
   process.env.API_BASE_URL?.trim() ||
@@ -232,7 +242,136 @@ const options: swaggerJsdoc.Options = {
   },
   // Scan all route files so any `@openapi` blocks are included.
   // (Many endpoints document OpenAPI inline in their route file, not only in `*.swagger.ts`.)
-  apis: ['./src/routes/*.ts', './src/index.ts'],
+  //
+  // Resolved from this file rather than the working directory: the server runs
+  // from `api/`, but the docs generator runs from the repo root, and a relative
+  // glob silently matches nothing from the wrong place — producing a spec with
+  // no hand-written detail in it at all.
+  apis: [
+    path.join(API_SRC, 'routes', '*.ts'),
+    path.join(API_SRC, 'index.ts'),
+  ],
 };
 
-export const swaggerSpec = swaggerJsdoc(options);
+/** How each guard maps onto the security schemes declared above. */
+const SECURITY_BY_GUARD: Record<Guard, Array<Record<string, string[]>>> = {
+  admin: [{ bearerAuth: [] }, { apiToken: [] }],
+  'server token': [{ matchzyServerToken: [] }],
+};
+
+interface OperationObject {
+  tags?: string[];
+  summary?: string;
+  description?: string;
+  security?: Array<Record<string, string[]>>;
+  parameters?: Array<Record<string, unknown>>;
+  responses?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+type PathsObject = Record<string, Record<string, OperationObject>>;
+
+/**
+ * Build the OpenAPI spec: hand-written `@openapi` blocks, completed from the
+ * routers.
+ *
+ * The annotations carry what a walk cannot infer — request bodies, response
+ * schemas, prose. They also only cover about a third of the endpoints, and
+ * nothing makes anyone write one for a new route. So the walk supplies the
+ * skeleton for everything, and an annotation wins wherever it exists.
+ *
+ * The one thing the walk always overrides is `security`. An annotation saying
+ * an endpoint is open when `requireAuth` guards it (or the reverse) is worse
+ * than no annotation, because it is believed. The middleware is the truth.
+ */
+export function buildOpenApiSpec(): Record<string, unknown> {
+  const spec = swaggerJsdoc(options) as Record<string, unknown> & { paths?: PathsObject };
+  const paths: PathsObject = spec.paths ?? {};
+
+  for (const group of collectRouterGroups()) {
+    for (const endpoint of group.endpoints) {
+      const openApiPath = toOpenApiPath(endpoint.path);
+      const method = endpoint.method.toLowerCase();
+
+      // OpenAPI has no vocabulary for these, and Express registers HEAD for
+      // free alongside GET.
+      if (method === 'head' || method === 'options') continue;
+
+      // A shadowed registration never runs, so describing it would misreport
+      // the endpoint — `GET /api/tournament/{id}/leaderboard` is registered
+      // public and then again admin-guarded, and the public one is what
+      // answers. Skipping keeps the first, which is the one Express matches.
+      if (endpoint.shadowed) continue;
+
+      const forPath = (paths[openApiPath] ??= {});
+      const existing = forPath[method];
+
+      const operation: OperationObject = existing ?? {
+        tags: [group.title],
+        summary: `${endpoint.method} ${endpoint.path}`,
+        description:
+          'Generated from the router. No hand-written `@openapi` block exists ' +
+          'for this endpoint yet, so the request and response shapes are not ' +
+          'described — read the handler.',
+        responses: {
+          200: { description: 'Success' },
+        },
+      };
+
+      // Declare path parameters, without clobbering richer hand-written ones.
+      const params = pathParams(endpoint.path);
+      if (params.length > 0) {
+        const declared = new Set(
+          (operation.parameters ?? [])
+            .filter((p) => (p as { in?: string }).in === 'path')
+            .map((p) => (p as { name?: string }).name)
+        );
+        const missing = params
+          .filter((name) => !declared.has(name))
+          .map((name) => ({
+            name,
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          }));
+        if (missing.length > 0) {
+          operation.parameters = [...(operation.parameters ?? []), ...missing];
+        }
+      }
+
+      // Always the walk's answer — see the note above.
+      const security = endpoint.guards.flatMap((guard) => SECURITY_BY_GUARD[guard]);
+      if (security.length > 0) {
+        operation.security = security;
+      } else {
+        delete operation.security;
+      }
+
+      if (!operation.tags || operation.tags.length === 0) {
+        operation.tags = [group.title];
+      }
+
+      forPath[method] = operation;
+    }
+  }
+
+  spec.paths = paths;
+  spec.tags = buildTags(spec.tags as Array<{ name: string; description?: string }> | undefined);
+  return spec;
+}
+
+/** Keep the hand-written tag descriptions, add one per router group. */
+function buildTags(
+  existing: Array<{ name: string; description?: string }> | undefined
+): Array<{ name: string; description?: string }> {
+  const byName = new Map<string, { name: string; description?: string }>();
+  for (const tag of existing ?? []) byName.set(tag.name, tag);
+  for (const group of collectRouterGroups()) {
+    if (!byName.has(group.title)) {
+      byName.set(group.title, { name: group.title, description: group.description });
+    }
+  }
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export const swaggerSpec = buildOpenApiSpec();

--- a/api/src/routes/templates.ts
+++ b/api/src/routes/templates.ts
@@ -141,7 +141,7 @@ router.post('/', async (req: Request, res: Response) => {
 
 /**
  * @openapi
- * /api/templates/:id:
+ * /api/templates/{id}:
  *   get:
  *     tags:
  *       - Templates
@@ -188,7 +188,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 
 /**
  * @openapi
- * /api/templates/:id:
+ * /api/templates/{id}:
  *   put:
  *     tags:
  *       - Templates
@@ -244,7 +244,7 @@ router.put('/:id', async (req: Request, res: Response) => {
 
 /**
  * @openapi
- * /api/templates/:id:
+ * /api/templates/{id}:
  *   delete:
  *     tags:
  *       - Templates

--- a/api/src/utils/routeIntrospection.ts
+++ b/api/src/utils/routeIntrospection.ts
@@ -1,0 +1,151 @@
+/**
+ * Reading the routes off the routers themselves.
+ *
+ * Every Express router carries a `stack` of layers: a layer with a `route` is
+ * an endpoint, and a layer without one is middleware applied to everything
+ * registered after it. That is enough to recover both the path list and which
+ * endpoints are guarded, because the auth middleware appears in the stack under
+ * its own function name — whether applied per-route
+ * (`router.get(path, requireAuth, handler)`) or to a whole router
+ * (`router.use(requireAuth)`).
+ *
+ * Two things consume this, and they must not disagree:
+ *   - `scripts/generate-api-reference.ts` → docs/API-REFERENCE.md
+ *   - `config/swagger` → the OpenAPI spec at /api-docs.json
+ *
+ * Hence one walk, here, rather than one in each.
+ */
+
+import { routeTable } from '../routes/routeTable';
+
+/** What a caller has to present. */
+export type Guard = 'admin' | 'server token';
+
+/** Middleware function names we recognise, and what they mean for a caller. */
+const GUARD_BY_MIDDLEWARE: Record<string, Guard> = {
+  requireAuth: 'admin',
+  validateServerToken: 'server token',
+  validateEventToken: 'server token',
+};
+
+export interface Endpoint {
+  method: string;
+  /** Full path including the mount prefix, in Express form (`/api/teams/:id`). */
+  path: string;
+  guards: Guard[];
+  /**
+   * True when an identical method+path was registered earlier and therefore
+   * always wins. Express matches in registration order, so a shadowed route is
+   * dead code — and a dangerous kind, because it reads as if it were in force.
+   *
+   * `GET /api/tournament/:id/leaderboard` is registered twice: once before
+   * `router.use(requireAuth)` and once after. The second looks admin-guarded
+   * and never runs, so the endpoint is public.
+   */
+  shadowed?: boolean;
+}
+
+export interface EndpointGroup {
+  title: string;
+  description: string;
+  prefix: string;
+  endpoints: Endpoint[];
+}
+
+// Express layer internals. Typed loosely on purpose: this is a private shape,
+// and pinning it exactly would turn an Express upgrade into a type error rather
+// than the runtime check in `walkRouter`, which explains itself far better.
+interface Layer {
+  name?: string;
+  route?: {
+    path: string | string[];
+    methods: Record<string, boolean>;
+    stack: Array<{ name?: string }>;
+  };
+}
+
+/**
+ * Walk one router in registration order.
+ *
+ * Router-level middleware applies to everything registered *after* it, so
+ * guards accumulate as we go rather than being read per route. Several routers
+ * rely on that: `teams`, `settings` and `servers` guard the whole file with a
+ * single `use`, `matches` guards route by route, and `tournament` and `players`
+ * do both — switching partway down the file.
+ */
+export function walkRouter(router: unknown, prefix = ''): Endpoint[] {
+  const stack = (router as { stack?: Layer[] }).stack;
+
+  if (!Array.isArray(stack)) {
+    throw new Error(
+      'Router has no `stack` array. Express changed its internals, so route ' +
+        'introspection can no longer see the routes and would silently report ' +
+        'an empty API. Fix the walk in utils/routeIntrospection.ts.'
+    );
+  }
+
+  const endpoints: Endpoint[] = [];
+  const routerGuards: Guard[] = [];
+
+  for (const layer of stack) {
+    if (!layer.route) {
+      const guard = layer.name ? GUARD_BY_MIDDLEWARE[layer.name] : undefined;
+      if (guard && !routerGuards.includes(guard)) routerGuards.push(guard);
+      continue;
+    }
+
+    const routeGuards: Guard[] = [...routerGuards];
+    for (const handler of layer.route.stack) {
+      const guard = handler.name ? GUARD_BY_MIDDLEWARE[handler.name] : undefined;
+      if (guard && !routeGuards.includes(guard)) routeGuards.push(guard);
+    }
+
+    const paths = Array.isArray(layer.route.path) ? layer.route.path : [layer.route.path];
+    for (const routePath of paths) {
+      // `/` as a router path means the mount prefix itself.
+      const full = routePath === '/' ? prefix || '/' : `${prefix}${routePath}`;
+      for (const method of Object.keys(layer.route.methods)) {
+        endpoints.push({ method: method.toUpperCase(), path: full, guards: routeGuards });
+      }
+    }
+  }
+
+  return endpoints;
+}
+
+/**
+ * Every mounted router, walked, in mount order, with shadowed routes marked.
+ *
+ * Shadowing is resolved across the whole table rather than per router:
+ * `/api/servers` has three routers on the same prefix, so a route in a later
+ * one can be shadowed by an earlier one just as easily as by a sibling.
+ */
+export function collectRouterGroups(): EndpointGroup[] {
+  const seen = new Set<string>();
+
+  return routeTable.map((mount) => ({
+    title: mount.title,
+    description: mount.description,
+    prefix: mount.prefix,
+    endpoints: walkRouter(mount.router, mount.prefix).map((endpoint) => {
+      const key = `${endpoint.method} ${endpoint.path}`;
+      if (seen.has(key)) return { ...endpoint, shadowed: true };
+      seen.add(key);
+      return endpoint;
+    }),
+  }));
+}
+
+/** Express `/api/teams/:id` → OpenAPI `/api/teams/{id}`. */
+export function toOpenApiPath(expressPath: string): string {
+  return expressPath.replace(/:([A-Za-z0-9_]+)/g, '{$1}');
+}
+
+/** Path parameter names, in order of appearance. */
+export function pathParams(expressPath: string): string[] {
+  return [...expressPath.matchAll(/:([A-Za-z0-9_]+)/g)].map((m) => m[1]);
+}
+
+export function describeGuards(guards: Guard[]): string {
+  return guards.length === 0 ? 'public' : guards.join(' + ');
+}

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -11,11 +11,12 @@
 
 # API reference
 
-Every endpoint this API serves — 187 of them, 140 behind auth —
+Every endpoint this API serves — 187 of them, 138 behind auth —
 read directly from the routers rather than written down, so it cannot drift.
 
 For *how* to authenticate a bot or script, and a task-oriented tour of the
-endpoints worth using, see [API.md](API.md). This file is the index.
+endpoints worth using, see [API.md](API.md). To generate a client, use
+[openapi.json](openapi.json) — same walk, machine-readable.
 
 ## Reading the Auth column
 
@@ -29,6 +30,16 @@ endpoints worth using, see [API.md](API.md). This file is the index.
 the caller's identity from a cookie and change what they return, or reject the
 action further in — map veto is the notable one, since actions are attributed
 to a player. Read the handler before assuming an endpoint is anonymous.
+
+**shadowed** marks a registration that never runs: the same method and path was
+registered earlier, and Express matches in registration order. It is dead code,
+and the dangerous kind — it reads as though it were in force. Where a shadowed
+row claims different auth from the row above it, the row above is what answers.
+
+Currently shadowed:
+
+- `DELETE /api/matches/:slug`
+- `GET /api/tournament/:id/leaderboard`
 
 ## Endpoints
 
@@ -140,7 +151,7 @@ Create, load, restart and cancel matches; read match state.
 | `POST` | `/api/matches/:slug/reallocate` | admin |
 | `PATCH` | `/api/matches/:slug/status` | admin |
 | `POST` | `/api/matches/:slug/force-cancel` | admin |
-| `DELETE` | `/api/matches/:slug` | admin |
+| `DELETE` | `/api/matches/:slug` | ~~admin~~ **shadowed** |
 
 ### Events
 
@@ -194,7 +205,7 @@ The tournament itself — setup, bracket, rounds, standings.
 | `POST` | `/api/tournament/:id/register-players` | admin |
 | `PUT` | `/api/tournament/:id/set-players` | admin |
 | `GET` | `/api/tournament/:id/players` | admin |
-| `GET` | `/api/tournament/:id/leaderboard` | admin |
+| `GET` | `/api/tournament/:id/leaderboard` | ~~admin~~ **shadowed** |
 | `GET` | `/api/tournament/:id/round-status` | admin |
 | `POST` | `/api/tournament/:id/generate-round` | admin |
 | `GET` | `/api/tournament/:id/elo-template` | admin |

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,13 +5,47 @@ can do, another program can do — run a tournament from Discord, post scoreboar
 to a channel, wire match results into something else.
 
 This document covers how a machine authenticates, and a task-oriented tour of
-the endpoints worth using. For the **complete** list — every endpoint and what
-guards it, generated from the routers themselves — see
-[API-REFERENCE.md](API-REFERENCE.md).
+the endpoints worth using.
 
-A Swagger UI is also served at `/api-docs` on a running instance
-(`/api-docs.json` for the raw spec), but its annotations cover only part of the
-surface; the generated reference is the one that is complete.
+Three other things, all generated from the routers themselves so none of them
+can drift from the code:
+
+| | What it is |
+| --- | --- |
+| [API-REFERENCE.md](API-REFERENCE.md) | Every endpoint and what guards it, to read |
+| [openapi.json](openapi.json) | The same, machine-readable — generate a client from it |
+| `/api-docs` on a running instance | Swagger UI over that spec, with a Try-it button |
+
+## Generating a client
+
+`docs/openapi.json` is a complete OpenAPI 3.0 document. Point any generator at
+it and get a typed client, without needing a MAT instance running:
+
+```bash
+# TypeScript types only — no runtime, no dependencies in your bot
+npx openapi-typescript docs/openapi.json -o src/mat-api.d.ts
+```
+
+```bash
+# A full client, in whatever language
+npx @openapitools/openapi-generator-cli generate \
+  -i docs/openapi.json -g typescript-fetch -o src/generated
+```
+
+A live instance serves the identical document at `/api-docs.json`, so a bot can
+also regenerate against the deployment it actually talks to:
+
+```bash
+curl -s https://mat.example.com/api-docs.json -o openapi.json
+```
+
+**What the spec does and does not carry.** Paths, methods, path parameters and
+`security` come from the routers, so they are complete and correct for every
+endpoint. Request and response *schemas* only exist where someone wrote an
+`@openapi` block — around a third of the surface. The rest are marked as
+generated and say to read the handler. That is worth knowing before you trust a
+generated response type: the endpoint list is authoritative, the response bodies
+are not, yet.
 
 ---
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,5580 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "MatchZy Auto Tournament API",
+    "version": "1.0.0",
+    "description": "API for managing CS2 tournament servers with secure RCON control",
+    "contact": {
+      "name": "API Support"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000",
+      "description": "API server (from API_BASE_URL, FRONTEND_BASE_URL, or localhost)"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "opaque",
+        "description": "Service token for machine clients (bots, scripts, CI). Send `Authorization: Bearer <token>`, where the token is one configured in API_TOKENS (full admin) or API_TOKENS_READONLY (GET only). Human admins authenticate with a session cookie instead."
+      },
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "opaque",
+        "description": "Service token for machine clients (bots, scripts, CI). Send `Authorization: Bearer <token>`, where the token is one configured in API_TOKENS (full admin) or API_TOKENS_READONLY (GET only). Human admins authenticate with a session cookie instead."
+      },
+      "apiToken": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Token",
+        "description": "Service token, as an alternative to `Authorization: Bearer <token>`."
+      },
+      "matchzyServerToken": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-MatchZy-Token",
+        "description": "Server-to-API authentication (webhooks, reports, demo uploads). Send `X-MatchZy-Token: <token>`."
+      }
+    },
+    "schemas": {
+      "Server": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique server identifier",
+            "example": "cs1"
+          },
+          "name": {
+            "type": "string",
+            "description": "Server display name",
+            "example": "Server #1"
+          },
+          "host": {
+            "type": "string",
+            "description": "Server IP address or hostname",
+            "example": "192.168.254.232"
+          },
+          "port": {
+            "type": "integer",
+            "description": "Server port",
+            "example": 27015
+          },
+          "password": {
+            "type": "string",
+            "description": "RCON password",
+            "example": "rcon_password"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the server is enabled",
+            "example": true
+          },
+          "created_at": {
+            "type": "integer",
+            "description": "Unix timestamp of creation",
+            "example": 1699000000
+          },
+          "updated_at": {
+            "type": "integer",
+            "description": "Unix timestamp of last update",
+            "example": 1699000000
+          }
+        }
+      },
+      "CreateServerInput": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "host",
+          "port",
+          "password"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique server identifier",
+            "example": "cs1"
+          },
+          "name": {
+            "type": "string",
+            "description": "Server display name",
+            "example": "Server #1"
+          },
+          "host": {
+            "type": "string",
+            "description": "Server IP address or hostname",
+            "example": "192.168.254.232"
+          },
+          "port": {
+            "type": "integer",
+            "description": "Server port (1-65535)",
+            "example": 27015
+          },
+          "password": {
+            "type": "string",
+            "description": "RCON password",
+            "example": "rcon_password"
+          }
+        }
+      },
+      "UpdateServerInput": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Server display name",
+            "example": "Server #1 Updated"
+          },
+          "host": {
+            "type": "string",
+            "description": "Server IP address or hostname",
+            "example": "192.168.254.232"
+          },
+          "port": {
+            "type": "integer",
+            "description": "Server port (1-65535)",
+            "example": 27015
+          },
+          "password": {
+            "type": "string",
+            "description": "RCON password",
+            "example": "new_password"
+          }
+        }
+      },
+      "RconResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "serverId": {
+            "type": "string",
+            "example": "cs1"
+          },
+          "serverName": {
+            "type": "string",
+            "example": "Server #1"
+          },
+          "command": {
+            "type": "string",
+            "example": "css_start"
+          },
+          "response": {
+            "type": "string",
+            "example": "Match started"
+          },
+          "error": {
+            "type": "string",
+            "example": "Connection timeout"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "error": {
+            "type": "string",
+            "example": "Error message"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Auth",
+      "description": "Sign-in flows, admin identity, impersonation."
+    },
+    {
+      "name": "Demos",
+      "description": "Demo upload from the game server, and download."
+    },
+    {
+      "name": "ELO templates",
+      "description": "Rating calculation presets."
+    },
+    {
+      "name": "Events",
+      "description": "MatchZy webhooks in, and the recorded event log out."
+    },
+    {
+      "name": "Generation",
+      "description": "Shared generators, e.g. random team names."
+    },
+    {
+      "name": "Health",
+      "description": "Health check endpoints"
+    },
+    {
+      "name": "Logs",
+      "description": "Server-side event logs."
+    },
+    {
+      "name": "Manual match templates",
+      "description": "Saved configurations for one-off matches."
+    },
+    {
+      "name": "Map pools",
+      "description": "Named sets of maps for veto and match config."
+    },
+    {
+      "name": "Maps",
+      "description": "The map catalogue."
+    },
+    {
+      "name": "Matches",
+      "description": "Create, load, restart and cancel matches; read match state."
+    },
+    {
+      "name": "MatchZy",
+      "description": "MatchZy Enhanced version information."
+    },
+    {
+      "name": "Players",
+      "description": "Player records, ratings, match history and profiles."
+    },
+    {
+      "name": "RCON",
+      "description": "RCON command endpoints (authentication required)"
+    },
+    {
+      "name": "Recovery",
+      "description": "Reconcile matches after an API restart or a server going away."
+    },
+    {
+      "name": "Server bootstrap",
+      "description": "Self-registration for a CS2 server coming online."
+    },
+    {
+      "name": "Server status",
+      "description": "Liveness, connectivity and CS2 update state per server."
+    },
+    {
+      "name": "Servers",
+      "description": "Server management endpoints"
+    },
+    {
+      "name": "Settings",
+      "description": "Instance-wide settings."
+    },
+    {
+      "name": "Steam",
+      "description": "Steam Web API lookups (profiles, avatars, key health)."
+    },
+    {
+      "name": "Team match view",
+      "description": "A team's current match, oriented to that team. Public."
+    },
+    {
+      "name": "Team stats",
+      "description": "Past results and aggregates for a team. Public."
+    },
+    {
+      "name": "Teams",
+      "description": "Team roster CRUD, including batch create and delete."
+    },
+    {
+      "name": "Test helpers",
+      "description": "E2E helpers. Disabled in production unless ENABLE_TEST_ENDPOINTS is set."
+    },
+    {
+      "name": "Tournament",
+      "description": "The tournament itself — setup, bracket, rounds, standings."
+    },
+    {
+      "name": "Tournament templates",
+      "description": "Saved tournament configurations."
+    },
+    {
+      "name": "Veto",
+      "description": "Map veto state and actions."
+    }
+  ],
+  "paths": {
+    "/api/tournament/{id}/leaderboard": {
+      "get": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Get player leaderboard for shuffle tournament",
+        "description": "Returns leaderboard sorted by match wins, then ELO. Includes player stats (wins, losses, win rate, ELO change).",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Tournament ID (currently only \"1\" is supported)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard retrieved successfully"
+          },
+          "400": {
+            "description": "Invalid tournament ID"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/tournament": {
+      "get": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Get current tournament",
+        "description": "Returns the current tournament configuration and status",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tournament retrieved successfully"
+          },
+          "404": {
+            "description": "No tournament exists"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Create new tournament",
+        "description": "Creates a new tournament (replaces existing if any)",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "type",
+                  "format",
+                  "maps",
+                  "teamIds"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "example": "Spring Cup 2026"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "single_elimination",
+                      "double_elimination",
+                      "round_robin",
+                      "swiss"
+                    ],
+                    "example": "single_elimination"
+                  },
+                  "format": {
+                    "type": "string",
+                    "enum": [
+                      "bo1",
+                      "bo3",
+                      "bo5"
+                    ],
+                    "example": "bo3"
+                  },
+                  "maps": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "de_mirage",
+                      "de_inferno",
+                      "de_ancient"
+                    ]
+                  },
+                  "teamIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "team1",
+                      "team2",
+                      "team3",
+                      "team4"
+                    ]
+                  },
+                  "settings": {
+                    "type": "object",
+                    "properties": {
+                      "thirdPlaceMatch": {
+                        "type": "boolean"
+                      },
+                      "autoAdvance": {
+                        "type": "boolean"
+                      },
+                      "checkInRequired": {
+                        "type": "boolean"
+                      },
+                      "seedingMethod": {
+                        "type": "string",
+                        "enum": [
+                          "random",
+                          "manual"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tournament created successfully"
+          },
+          "400": {
+            "description": "Invalid input"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Update tournament",
+        "description": "Update tournament settings (only allowed before tournament starts)",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tournament updated successfully"
+          },
+          "400": {
+            "description": "Invalid input or tournament already started"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Delete tournament",
+        "description": "Ends all matches on servers and deletes the current tournament and all associated data",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tournament deleted successfully"
+          }
+        }
+      }
+    },
+    "/api/tournament/bracket": {
+      "get": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Get tournament bracket",
+        "description": "Returns the tournament bracket with all matches",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bracket retrieved successfully"
+          },
+          "404": {
+            "description": "No tournament exists"
+          }
+        }
+      }
+    },
+    "/api/tournament/bracket/regenerate": {
+      "post": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Regenerate tournament bracket (DESTRUCTIVE)",
+        "description": "Deletes all existing matches and regenerates bracket. Requires force=true for live tournaments.",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "force": {
+                    "type": "boolean",
+                    "description": "Set to true to regenerate bracket for live tournament (destroys match data)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bracket regenerated successfully"
+          },
+          "400": {
+            "description": "Cannot regenerate bracket without force flag"
+          }
+        }
+      }
+    },
+    "/api/tournament/reset": {
+      "post": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Reset tournament to setup mode",
+        "description": "Ends all matches on servers and resets tournament status to setup",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tournament reset successfully"
+          }
+        }
+      }
+    },
+    "/api/tournament/start": {
+      "post": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Start tournament and allocate servers",
+        "description": "Automatically allocates available servers to ready matches and loads them via RCON. Updates tournament status to 'in_progress'.",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tournament started successfully with match allocation results"
+          },
+          "400": {
+            "description": "Tournament not ready or no available servers"
+          },
+          "404": {
+            "description": "No tournament exists"
+          }
+        }
+      }
+    },
+    "/api/tournament/server-availability": {
+      "get": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Get available server count",
+        "description": "Returns the number of servers currently available for match allocation",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server availability retrieved successfully"
+          }
+        }
+      }
+    },
+    "/api/tournament/restart": {
+      "post": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Restart tournament matches and reallocate servers",
+        "description": "Runs css_restart on all servers with loaded/live matches, resets matches to ready status, then reallocates servers. Useful for restarting stuck matches.",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tournament restarted successfully with allocation results"
+          },
+          "400": {
+            "description": "Tournament not ready or restart failed"
+          },
+          "404": {
+            "description": "No tournament exists"
+          }
+        }
+      }
+    },
+    "/api/tournament/wipe-database": {
+      "post": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Reset entire database (DEV ONLY)",
+        "description": "Drops all tables and reinitializes the database schema with default data (maps, map pools). This resets the database to its initial state as if starting fresh. USE WITH CAUTION!",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Database reset successfully"
+          }
+        }
+      }
+    },
+    "/api/tournament/wipe-table/{table}": {
+      "post": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Wipe specific table (DEV ONLY)",
+        "description": "Deletes all data from a specific table",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "table",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "teams",
+                "servers",
+                "tournament",
+                "matches",
+                "players",
+                "maps",
+                "map_pools",
+                "tournament_templates",
+                "elo_calculation_templates",
+                "match_events",
+                "match_map_results",
+                "player_rating_history",
+                "player_match_stats",
+                "shuffle_tournament_players",
+                "app_settings"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Table wiped successfully"
+          }
+        }
+      }
+    },
+    "/api/tournament/dev/reset-simulation-state": {
+      "post": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Reset simulation state while preserving core configuration (DEV ONLY)",
+        "description": "Clears all matches, match events, map results, player match stats, and rating history so you can restart simulations from a clean slate, while preserving servers, teams, maps, map pools, and the current tournament configuration (name, type, maps, teams, settings). Player records are kept, but their current ELO and match counts are reset based on their starting values.\n",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Simulation state reset successfully"
+          },
+          "500": {
+            "description": "Failed to reset simulation state"
+          }
+        }
+      }
+    },
+    "/api/tournament/shuffle": {
+      "post": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Create a shuffle tournament",
+        "description": "Creates a new shuffle tournament with dynamic team balancing. Shuffle tournaments are individual player competitions where teams are automatically balanced and reshuffled each round based on ELO ratings.",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "mapSequence",
+                  "maxRounds",
+                  "overtimeMode"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Tournament name",
+                    "example": "LAN Party 2025"
+                  },
+                  "mapSequence": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of maps in order (number of maps = number of rounds)",
+                    "example": [
+                      "de_dust2",
+                      "de_mirage",
+                      "de_inferno"
+                    ]
+                  },
+                  "maxRounds": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 30,
+                    "description": "Maximum rounds per match (maps end after this many rounds)",
+                    "example": 24
+                  },
+                  "overtimeMode": {
+                    "type": "string",
+                    "enum": [
+                      "enabled",
+                      "disabled"
+                    ],
+                    "description": "Overtime handling mode",
+                    "example": "enabled"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Shuffle tournament created successfully"
+          },
+          "400": {
+            "description": "Invalid request or missing required fields"
+          }
+        }
+      }
+    },
+    "/api/tournament/{id}/register-players": {
+      "post": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Register players to shuffle tournament",
+        "description": "Register one or more players to a shuffle tournament. Players must exist in the players table. Only works when tournament is in \"setup\" status.",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Tournament ID (currently only \"1\" is supported)"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "playerIds"
+                ],
+                "properties": {
+                  "playerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of player Steam IDs to register",
+                    "example": [
+                      "76561198000000000",
+                      "76561198000000001"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "All players registered successfully"
+          },
+          "207": {
+            "description": "Some players registered, some failed (Multi-Status)"
+          },
+          "400": {
+            "description": "Invalid request, tournament not in setup status, or tournament not found"
+          }
+        }
+      }
+    },
+    "/api/tournament/{id}/set-players": {
+      "put": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Set registered players for shuffle tournament (replaces all)",
+        "description": "Sets the complete list of registered players. Players not in the list will be unregistered, new players will be registered.",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Tournament ID (currently only \"1\" is supported)"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "playerIds"
+                ],
+                "properties": {
+                  "playerIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Complete list of player Steam IDs to register (replaces all existing registrations)",
+                    "example": [
+                      "76561198000000000",
+                      "76561198000000001"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Players updated successfully"
+          },
+          "207": {
+            "description": "Some players updated, some failed (Multi-Status)"
+          },
+          "400": {
+            "description": "Invalid request, tournament not in setup status, or tournament not found"
+          }
+        }
+      }
+    },
+    "/api/tournament/{id}/players": {
+      "get": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Get registered players for shuffle tournament",
+        "description": "Returns list of all players registered for the shuffle tournament with their current ELO ratings.",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Tournament ID (currently only \"1\" is supported)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Registered players retrieved successfully"
+          },
+          "400": {
+            "description": "Invalid tournament ID"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/tournament/{id}/round-status": {
+      "get": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "Get current round status for shuffle tournament",
+        "description": "Returns current round number, map, match completion status, and progress. Used for displaying round status indicators.",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Tournament ID (currently only \"1\" is supported)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Round status retrieved successfully"
+          },
+          "400": {
+            "description": "Invalid tournament ID or not a shuffle tournament"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/test/marker": {
+      "post": {
+        "tags": [
+          "Testing"
+        ],
+        "summary": "Write a sanitized test marker to the API logs",
+        "description": "Helper endpoint for E2E tests to label log output with the current test name or context. The message is sanitized (length-limited and restricted to safe characters) before logging.\n",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Free-form test marker (will be sanitized)",
+                    "example": "Shuffle Tournament API - should update player ELO after match completion"
+                  },
+                  "scope": {
+                    "type": "string",
+                    "description": "Optional scope or shard identifier",
+                    "example": "shard-1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Marker written to logs"
+          },
+          "400": {
+            "description": "Invalid request payload"
+          }
+        }
+      }
+    },
+    "/api/test/reset-database": {
+      "post": {
+        "tags": [
+          "Testing"
+        ],
+        "summary": "Reset database (development only)",
+        "description": "Drops and recreates the entire database schema and re-initializes default data. This endpoint is **development only** and is disabled when NODE_ENV=production.\n",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Database was reset and reinitialized successfully"
+          },
+          "403": {
+            "description": "Disabled in production environments"
+          },
+          "500": {
+            "description": "Failed to reset database"
+          }
+        }
+      }
+    },
+    "/api/templates": {
+      "get": {
+        "tags": [
+          "Templates"
+        ],
+        "summary": "Get all tournament templates",
+        "description": "Returns all saved tournament templates",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Templates retrieved successfully"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Templates"
+        ],
+        "summary": "Create a new tournament template",
+        "description": "Creates a new tournament template from the provided configuration",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "type",
+                  "format"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "example": "8-team Single Elim BO3"
+                  },
+                  "description": {
+                    "type": "string",
+                    "example": "Weekly 8-team single elimination tournament"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "single_elimination",
+                      "double_elimination",
+                      "round_robin",
+                      "swiss"
+                    ]
+                  },
+                  "format": {
+                    "type": "string",
+                    "enum": [
+                      "bo1",
+                      "bo3",
+                      "bo5"
+                    ]
+                  },
+                  "mapPoolId": {
+                    "type": "number",
+                    "nullable": true
+                  },
+                  "maps": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "settings": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Template created successfully"
+          },
+          "400": {
+            "description": "Invalid input"
+          }
+        }
+      }
+    },
+    "/api/templates/{id}": {
+      "get": {
+        "tags": [
+          "Templates"
+        ],
+        "summary": "Get template by ID",
+        "description": "Returns a specific tournament template",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Template retrieved successfully"
+          },
+          "404": {
+            "description": "Template not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Templates"
+        ],
+        "summary": "Update tournament template",
+        "description": "Updates an existing tournament template",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Template updated successfully"
+          },
+          "404": {
+            "description": "Template not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Templates"
+        ],
+        "summary": "Delete tournament template",
+        "description": "Deletes a tournament template",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Template deleted successfully"
+          },
+          "404": {
+            "description": "Template not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/steam/status": {
+      "get": {
+        "tags": [
+          "Steam"
+        ],
+        "summary": "Check Steam API connectivity",
+        "description": "Verifies whether a Steam Web API key is configured and reachable.",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Steam API status. Returns configured=true when key is set and reachable, otherwise configured=false."
+          },
+          "503": {
+            "description": "Steam API key is set but Steam could not be reached"
+          }
+        }
+      }
+    },
+    "/api/steam/resolve": {
+      "post": {
+        "tags": [
+          "Steam"
+        ],
+        "summary": "Resolve Steam vanity URL or ID to Steam ID64",
+        "description": "Resolves various Steam input formats (vanity URL, vanity ID, profile URL) to a Steam ID64 and fetches player info",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "input"
+                ],
+                "properties": {
+                  "input": {
+                    "type": "string",
+                    "description": "Steam vanity URL, vanity ID, profile URL, or Steam ID64",
+                    "example": "gaben"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully resolved"
+          },
+          "404": {
+            "description": "Could not resolve input"
+          },
+          "503": {
+            "description": "Steam API not configured"
+          }
+        }
+      }
+    },
+    "/api/steam/player/{steamId}": {
+      "get": {
+        "tags": [
+          "Steam"
+        ],
+        "summary": "Get player information by Steam ID64",
+        "description": "Fetches player name and avatar from Steam API",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "steamId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Steam ID64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Player information retrieved"
+          },
+          "404": {
+            "description": "Player not found"
+          },
+          "503": {
+            "description": "Steam API not configured"
+          }
+        }
+      }
+    },
+    "/api/servers": {
+      "get": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "List all servers",
+        "description": "Get all servers or filter by enabled status",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "enabled",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Filter by enabled servers only"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of servers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "count": {
+                      "type": "integer"
+                    },
+                    "servers": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Server"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "Create a new server",
+        "description": "Create a new server configuration",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "upsert",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "If true, update the server if it already exists"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateServerInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Server created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "server": {
+                      "$ref": "#/components/schemas/Server"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Server already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/servers/batch": {
+      "post": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "Create multiple servers",
+        "description": "Batch create servers. Use ?upsert=true to update existing servers.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "upsert",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "If true, update servers if they already exist"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CreateServerInput"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Servers created successfully"
+          },
+          "207": {
+            "description": "Partial success (some servers failed)"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "PATCH /api/servers/batch",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/servers/{id}": {
+      "get": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "Get server by ID",
+        "description": "Retrieve a specific server configuration",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Server ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "server": {
+                      "$ref": "#/components/schemas/Server"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Server not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "Update server (partial)",
+        "description": "Partially update a server configuration",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateServerInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Server updated"
+          },
+          "404": {
+            "description": "Server not found"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "Delete server",
+        "description": "Remove a server configuration",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server deleted"
+          },
+          "404": {
+            "description": "Server not found"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "PUT /api/servers/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/servers/{id}/enable": {
+      "post": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "Enable server",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server enabled"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/servers/{id}/disable": {
+      "post": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "Disable server",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server disabled"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/servers/{id}/status": {
+      "get": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "Test server RCON connection",
+        "description": "Attempts to connect to the server via RCON and returns online/offline status",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Server ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server status retrieved"
+          },
+          "404": {
+            "description": "Server not found"
+          }
+        }
+      }
+    },
+    "/api/rcon/test": {
+      "get": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "Test all RCON connections",
+        "description": "Test RCON connectivity to all enabled servers",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Test results"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/rcon/test/{serverId}": {
+      "get": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "Test RCON connection to specific server",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "serverId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Connection successful"
+          },
+          "400": {
+            "description": "Connection failed"
+          }
+        }
+      }
+    },
+    "/api/rcon/practice-mode": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "Start practice mode",
+        "description": "Execute css_prac command on server",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "serverId"
+                ],
+                "properties": {
+                  "serverId": {
+                    "type": "string",
+                    "example": "cs1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Command executed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RconResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/rcon/start-match": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "Force start match",
+        "description": "Execute css_start command on server",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "serverId"
+                ],
+                "properties": {
+                  "serverId": {
+                    "type": "string",
+                    "example": "cs1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Match started"
+          }
+        }
+      }
+    },
+    "/api/rcon/change-map": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "Change map",
+        "description": "Execute css_map command on server",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "serverId",
+                  "mapName"
+                ],
+                "properties": {
+                  "serverId": {
+                    "type": "string",
+                    "example": "cs1"
+                  },
+                  "mapName": {
+                    "type": "string",
+                    "example": "de_dust2",
+                    "description": "Map name (alphanumeric, underscores, hyphens only)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Map changed"
+          },
+          "400": {
+            "description": "Invalid map name"
+          }
+        }
+      }
+    },
+    "/api/rcon/pause-match": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "Pause match",
+        "description": "Execute css_pause command",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "serverId"
+                ],
+                "properties": {
+                  "serverId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Match paused"
+          }
+        }
+      }
+    },
+    "/api/rcon/unpause-match": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "Unpause match",
+        "description": "Execute css_unpause command",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "serverId"
+                ],
+                "properties": {
+                  "serverId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Match unpaused"
+          }
+        }
+      }
+    },
+    "/api/rcon/restart-match": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "Restart match",
+        "description": "Execute mp_restartgame command (restarts current round)",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "serverId"
+                ],
+                "properties": {
+                  "serverId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Match restarted"
+          }
+        }
+      }
+    },
+    "/api/rcon/end-warmup": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "End warmup",
+        "description": "Execute mp_warmup_end command",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "serverId"
+                ],
+                "properties": {
+                  "serverId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Warmup ended"
+          }
+        }
+      }
+    },
+    "/api/rcon/reload-admins": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "Reload admins",
+        "description": "Execute reload_admins command",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "serverId"
+                ],
+                "properties": {
+                  "serverId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Admins reloaded"
+          }
+        }
+      }
+    },
+    "/api/rcon/say": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "Send message to server",
+        "description": "Send a chat message to a specific server (sanitized, max 200 chars)",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "serverId",
+                  "message"
+                ],
+                "properties": {
+                  "serverId": {
+                    "type": "string",
+                    "example": "cs1"
+                  },
+                  "message": {
+                    "type": "string",
+                    "example": "Welcome to the tournament!",
+                    "maxLength": 200
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Message sent"
+          }
+        }
+      }
+    },
+    "/api/rcon/broadcast": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "Broadcast message",
+        "description": "Send a message to all servers or specific servers",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "message"
+                ],
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "Server maintenance in 10 minutes!",
+                    "maxLength": 200
+                  },
+                  "serverIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "cs1",
+                      "cs2",
+                      "cs3"
+                    ],
+                    "description": "Optional list of server IDs. If omitted, broadcasts to all enabled servers."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Broadcast successful"
+          },
+          "207": {
+            "description": "Partial success"
+          }
+        }
+      }
+    },
+    "/api/logs": {
+      "get": {
+        "tags": [
+          "Logs"
+        ],
+        "summary": "Get recent application logs",
+        "description": "Returns recent log entries for debugging and auditing",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 100
+            },
+            "description": "Maximum number of logs to return"
+          },
+          {
+            "in": "query",
+            "name": "level",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "debug",
+                "info",
+                "warn",
+                "error"
+              ]
+            },
+            "description": "Filter by log level"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Logs retrieved successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/auth/impersonate": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Current impersonation state for the signed-in admin",
+        "responses": {
+          "200": {
+            "description": "Impersonation state"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Start impersonating a player (admin only)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "steamId"
+                ],
+                "properties": {
+                  "steamId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Impersonation started"
+          },
+          "400": {
+            "description": "Invalid Steam ID"
+          },
+          "403": {
+            "description": "Target is an admin, or caller is not an admin"
+          },
+          "404": {
+            "description": "No such player"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/auth/impersonate/stop": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Stop impersonating and return to your own identity",
+        "responses": {
+          "200": {
+            "description": "Impersonation cleared"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Get API information",
+        "description": "Returns basic information about the API and available endpoints",
+        "responses": {
+          "200": {
+            "description": "API information"
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Health check",
+        "description": "Check if the API is running",
+        "responses": {
+          "200": {
+            "description": "API is healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2023-11-01T12:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/health/fleet": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Fleet health snapshot",
+        "description": "Quick operator snapshot of enabled servers and CS2 update status.",
+        "responses": {
+          "200": {
+            "description": "Fleet snapshot"
+          }
+        }
+      }
+    },
+    "/api/servers/{id}/bootstrap": {
+      "get": {
+        "tags": [
+          "Server bootstrap"
+        ],
+        "summary": "GET /api/servers/:id/bootstrap",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "matchzyServerToken": []
+          }
+        ]
+      }
+    },
+    "/api/servers/bulk-delete": {
+      "post": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "POST /api/servers/bulk-delete",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/servers/{id}/reset-initialization": {
+      "post": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "POST /api/servers/:id/reset-initialization",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/servers/reset-all-initialization": {
+      "post": {
+        "tags": [
+          "Servers"
+        ],
+        "summary": "POST /api/servers/reset-all-initialization",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/teams": {
+      "get": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "GET /api/teams",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "POST /api/teams",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/teams/{id}": {
+      "get": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "GET /api/teams/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "PUT /api/teams/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "DELETE /api/teams/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/teams/batch": {
+      "patch": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "PATCH /api/teams/batch",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/teams/bulk-delete": {
+      "post": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "POST /api/teams/bulk-delete",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/rcon/test-connection": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "POST /api/rcon/test-connection",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/rcon/force-pause": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "POST /api/rcon/force-pause",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/rcon/force-unpause": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "POST /api/rcon/force-unpause",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/rcon/swap-teams": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "POST /api/rcon/swap-teams",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/rcon/restore-backup": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "POST /api/rcon/restore-backup",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/rcon/skip-veto": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "POST /api/rcon/skip-veto",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/rcon/restart-round": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "POST /api/rcon/restart-round",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/rcon/add-time": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "POST /api/rcon/add-time",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/rcon/end-match": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "POST /api/rcon/end-match",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/rcon/{serverId}/add-player": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "POST /api/rcon/:serverId/add-player",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "serverId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/rcon/command": {
+      "post": {
+        "tags": [
+          "RCON"
+        ],
+        "summary": "POST /api/rcon/command",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/matches/{slug}.json": {
+      "get": {
+        "tags": [
+          "Matches"
+        ],
+        "summary": "GET /api/matches/:slug.json",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/matches/{slug}": {
+      "delete": {
+        "tags": [
+          "Matches"
+        ],
+        "summary": "DELETE /api/matches/:slug",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "get": {
+        "tags": [
+          "Matches"
+        ],
+        "summary": "GET /api/matches/:slug",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/matches/bulk-delete": {
+      "post": {
+        "tags": [
+          "Matches"
+        ],
+        "summary": "POST /api/matches/bulk-delete",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/matches": {
+      "get": {
+        "tags": [
+          "Matches"
+        ],
+        "summary": "GET /api/matches",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Matches"
+        ],
+        "summary": "POST /api/matches",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/matches/{slug}/load": {
+      "post": {
+        "tags": [
+          "Matches"
+        ],
+        "summary": "POST /api/matches/:slug/load",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/matches/{slug}/restart": {
+      "post": {
+        "tags": [
+          "Matches"
+        ],
+        "summary": "POST /api/matches/:slug/restart",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/matches/{slug}/reallocate": {
+      "post": {
+        "tags": [
+          "Matches"
+        ],
+        "summary": "POST /api/matches/:slug/reallocate",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/matches/{slug}/status": {
+      "patch": {
+        "tags": [
+          "Matches"
+        ],
+        "summary": "PATCH /api/matches/:slug/status",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/matches/{slug}/force-cancel": {
+      "post": {
+        "tags": [
+          "Matches"
+        ],
+        "summary": "POST /api/matches/:slug/force-cancel",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/events/test": {
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "summary": "GET /api/events/test",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/events": {
+      "post": {
+        "tags": [
+          "Events"
+        ],
+        "summary": "POST /api/events",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "matchzyServerToken": []
+          }
+        ]
+      }
+    },
+    "/api/events/report": {
+      "post": {
+        "tags": [
+          "Events"
+        ],
+        "summary": "POST /api/events/report",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "matchzyServerToken": []
+          }
+        ]
+      }
+    },
+    "/api/events/{matchSlugOrServerId}": {
+      "post": {
+        "tags": [
+          "Events"
+        ],
+        "summary": "POST /api/events/:matchSlugOrServerId",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "matchSlugOrServerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "matchzyServerToken": []
+          }
+        ]
+      }
+    },
+    "/api/events/connections/{matchSlug}": {
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "summary": "GET /api/events/connections/:matchSlug",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "matchSlug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/events/live/{matchSlug}": {
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "summary": "GET /api/events/live/:matchSlug",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "matchSlug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/events/server/{serverId}": {
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "summary": "GET /api/events/server/:serverId",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "serverId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/events/{matchSlug}": {
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "summary": "GET /api/events/:matchSlug",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "matchSlug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/steam/workshop-map": {
+      "get": {
+        "tags": [
+          "Steam"
+        ],
+        "summary": "GET /api/steam/workshop-map",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/tournament/allocation-status": {
+      "get": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "GET /api/tournament/allocation-status",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/tournament/{id}/manual-matches": {
+      "post": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "POST /api/tournament/:id/manual-matches",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/tournament/{id}/generate-round": {
+      "post": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "POST /api/tournament/:id/generate-round",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/tournament/{id}/elo-template": {
+      "get": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "GET /api/tournament/:id/elo-template",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "PUT /api/tournament/:id/elo-template",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/tournament/{id}/check-completion": {
+      "post": {
+        "tags": [
+          "Tournament"
+        ],
+        "summary": "POST /api/tournament/:id/check-completion",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/demos/{matchSlug}/upload": {
+      "post": {
+        "tags": [
+          "Demos"
+        ],
+        "summary": "POST /api/demos/:matchSlug/upload",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "matchSlug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "matchzyServerToken": []
+          }
+        ]
+      }
+    },
+    "/api/demos/{matchSlug}/download/{mapNumber}?": {
+      "get": {
+        "tags": [
+          "Demos"
+        ],
+        "summary": "GET /api/demos/:matchSlug/download/:mapNumber?",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "matchSlug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "mapNumber",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/demos/{matchSlug}/status": {
+      "get": {
+        "tags": [
+          "Demos"
+        ],
+        "summary": "GET /api/demos/:matchSlug/status",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "matchSlug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/demos/{matchSlug}/info": {
+      "get": {
+        "tags": [
+          "Demos"
+        ],
+        "summary": "GET /api/demos/:matchSlug/info",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "matchSlug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/team/{teamId}/match": {
+      "get": {
+        "tags": [
+          "Team match view"
+        ],
+        "summary": "GET /api/team/:teamId/match",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "teamId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/team/{teamId}/history": {
+      "get": {
+        "tags": [
+          "Team stats"
+        ],
+        "summary": "GET /api/team/:teamId/history",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "teamId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/team/{teamId}/stats": {
+      "get": {
+        "tags": [
+          "Team stats"
+        ],
+        "summary": "GET /api/team/:teamId/stats",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "teamId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/veto/{matchSlug}": {
+      "get": {
+        "tags": [
+          "Veto"
+        ],
+        "summary": "GET /api/veto/:matchSlug",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "matchSlug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/veto/{matchSlug}/action": {
+      "post": {
+        "tags": [
+          "Veto"
+        ],
+        "summary": "POST /api/veto/:matchSlug/action",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "matchSlug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/veto/{matchSlug}/reset": {
+      "post": {
+        "tags": [
+          "Veto"
+        ],
+        "summary": "POST /api/veto/:matchSlug/reset",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "matchSlug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/settings/version": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "GET /api/settings/version",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/settings": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "GET /api/settings",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "PUT /api/settings",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/maps": {
+      "get": {
+        "tags": [
+          "Maps"
+        ],
+        "summary": "GET /api/maps",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Maps"
+        ],
+        "summary": "POST /api/maps",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/maps/{id}": {
+      "get": {
+        "tags": [
+          "Maps"
+        ],
+        "summary": "GET /api/maps/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Maps"
+        ],
+        "summary": "PUT /api/maps/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Maps"
+        ],
+        "summary": "PATCH /api/maps/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Maps"
+        ],
+        "summary": "DELETE /api/maps/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/maps/{id}/upload-image": {
+      "post": {
+        "tags": [
+          "Maps"
+        ],
+        "summary": "POST /api/maps/:id/upload-image",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/maps/sync": {
+      "post": {
+        "tags": [
+          "Maps"
+        ],
+        "summary": "POST /api/maps/sync",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/map-pools": {
+      "get": {
+        "tags": [
+          "Map pools"
+        ],
+        "summary": "GET /api/map-pools",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Map pools"
+        ],
+        "summary": "POST /api/map-pools",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/map-pools/{id}": {
+      "get": {
+        "tags": [
+          "Map pools"
+        ],
+        "summary": "GET /api/map-pools/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Map pools"
+        ],
+        "summary": "PUT /api/map-pools/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Map pools"
+        ],
+        "summary": "DELETE /api/map-pools/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/map-pools/{id}/enable": {
+      "put": {
+        "tags": [
+          "Map pools"
+        ],
+        "summary": "PUT /api/map-pools/:id/enable",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/map-pools/{id}/disable": {
+      "put": {
+        "tags": [
+          "Map pools"
+        ],
+        "summary": "PUT /api/map-pools/:id/disable",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/map-pools/{id}/set-default": {
+      "put": {
+        "tags": [
+          "Map pools"
+        ],
+        "summary": "PUT /api/map-pools/:id/set-default",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/manual-match-templates": {
+      "get": {
+        "tags": [
+          "Manual match templates"
+        ],
+        "summary": "GET /api/manual-match-templates",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Manual match templates"
+        ],
+        "summary": "POST /api/manual-match-templates",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/recovery/recover": {
+      "post": {
+        "tags": [
+          "Recovery"
+        ],
+        "summary": "POST /api/recovery/recover",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/recovery/replay/{matchSlug}": {
+      "post": {
+        "tags": [
+          "Recovery"
+        ],
+        "summary": "POST /api/recovery/replay/:matchSlug",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "matchSlug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/players/find": {
+      "get": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "GET /api/players/find",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/players/public-selection": {
+      "get": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "GET /api/players/public-selection",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/players/selection": {
+      "get": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "GET /api/players/selection",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/players/{playerId}/team": {
+      "get": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "GET /api/players/:playerId/team",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "playerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/players/me/match-status": {
+      "get": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "GET /api/players/me/match-status",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/players/{playerId}/current-match": {
+      "get": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "GET /api/players/:playerId/current-match",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "playerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/players/{playerId}/summary": {
+      "get": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "GET /api/players/:playerId/summary",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "playerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/players/{playerId}/avatar.svg": {
+      "get": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "GET /api/players/:playerId/avatar.svg",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "playerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/players/{playerId}": {
+      "get": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "GET /api/players/:playerId",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "playerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "PUT /api/players/:playerId",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "playerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "DELETE /api/players/:playerId",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "playerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/players/{playerId}/rating-history": {
+      "get": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "GET /api/players/:playerId/rating-history",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "playerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/players/{playerId}/matches": {
+      "get": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "GET /api/players/:playerId/matches",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "playerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/players": {
+      "get": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "GET /api/players",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "POST /api/players",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/players/bulk-import": {
+      "post": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "POST /api/players/bulk-import",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/players/bulk-delete": {
+      "post": {
+        "tags": [
+          "Players"
+        ],
+        "summary": "POST /api/players/bulk-delete",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/elo-templates": {
+      "get": {
+        "tags": [
+          "ELO templates"
+        ],
+        "summary": "GET /api/elo-templates",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "ELO templates"
+        ],
+        "summary": "POST /api/elo-templates",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/elo-templates/{id}": {
+      "get": {
+        "tags": [
+          "ELO templates"
+        ],
+        "summary": "GET /api/elo-templates/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "ELO templates"
+        ],
+        "summary": "PUT /api/elo-templates/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "ELO templates"
+        ],
+        "summary": "DELETE /api/elo-templates/:id",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/generation/team-name": {
+      "get": {
+        "tags": [
+          "Generation"
+        ],
+        "summary": "GET /api/generation/team-name",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/test/server-status": {
+      "post": {
+        "tags": [
+          "Test helpers"
+        ],
+        "summary": "POST /api/test/server-status",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/test/match-state": {
+      "post": {
+        "tags": [
+          "Test helpers"
+        ],
+        "summary": "POST /api/test/match-state",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/test/match-report": {
+      "post": {
+        "tags": [
+          "Test helpers"
+        ],
+        "summary": "POST /api/test/match-report",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiToken": []
+          }
+        ]
+      }
+    },
+    "/api/test/login-admin": {
+      "post": {
+        "tags": [
+          "Test helpers"
+        ],
+        "summary": "POST /api/test/login-admin",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/test/login-player": {
+      "post": {
+        "tags": [
+          "Test helpers"
+        ],
+        "summary": "POST /api/test/login-player",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/steam": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "GET /api/auth/steam",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/steam/callback": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "GET /api/auth/steam/callback",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "POST /api/auth/logout",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/keycloak": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "GET /api/auth/keycloak",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/keycloak/callback": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "GET /api/auth/keycloak/callback",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/discord": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "GET /api/auth/discord",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/discord/callback": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "GET /api/auth/discord/callback",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/github": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "GET /api/auth/github",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/github/callback": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "GET /api/auth/github/callback",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/providers": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "GET /api/auth/providers",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/me": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "GET /api/auth/me",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/self-register": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "POST /api/auth/self-register",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/admin-status": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "GET /api/auth/admin-status",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/admin/me": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "GET /api/auth/admin/me",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/auth/admin/logout": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "POST /api/auth/admin/logout",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/matchzy/latest-version": {
+      "get": {
+        "tags": [
+          "MatchZy"
+        ],
+        "summary": "GET /api/matchzy/latest-version",
+        "description": "Generated from the router. No hand-written `@openapi` block exists for this endpoint yet, so the request and response shapes are not described — read the handler.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/generate-api-reference.ts
+++ b/scripts/generate-api-reference.ts
@@ -1,124 +1,47 @@
 /**
- * Generate docs/API-REFERENCE.md from the actual Express routers.
+ * Generate docs/API-REFERENCE.md and docs/openapi.json from the actual routers.
  *
  * Hand-written endpoint lists rot. `docs/API.md` covers the endpoints a bot
- * would want and stops there; the OpenAPI annotations cover about a third of
+ * would want and stops there; the `@openapi` annotations cover about a third of
  * the surface. Neither tells you what is actually mounted, and neither
  * complains when a route is added.
  *
- * This reads the routers themselves. Every router carries a `stack` of layers:
- * a layer with a `route` is an endpoint, and a layer without one is middleware
- * applied to everything registered after it. That is exactly enough to recover
- * both the path list and which of them are guarded, because `requireAuth` and
- * `validateServerToken` appear in the stack under their own function names —
- * whether applied per-route (`router.get(path, requireAuth, handler)`) or to a
- * whole router (`router.use(requireAuth)`).
+ * Both outputs come from the same walk (`utils/routeIntrospection`), which is
+ * also what the running server uses to build /api-docs.json — so the Markdown,
+ * the committed spec and the live spec cannot disagree.
+ *
+ * The committed `openapi.json` is the point of contact for anything outside
+ * this repo: generate a typed client from it, in any language, without needing
+ * a MAT instance to point at.
  *
  * Usage:
- *   yarn docs:api           # write docs/API-REFERENCE.md
- *   yarn docs:api --check   # exit 1 if the file is stale (used by CI)
+ *   yarn docs:api           # write both files
+ *   yarn docs:api --check   # exit 1 if either is stale (used by CI)
  */
 
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { routeTable } from '../api/src/routes/routeTable';
+import {
+  collectRouterGroups,
+  describeGuards,
+  type Endpoint,
+  type EndpointGroup,
+} from '../api/src/utils/routeIntrospection';
+import { buildOpenApiSpec } from '../api/src/config/swagger';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const OUTPUT = path.join(REPO_ROOT, 'docs', 'API-REFERENCE.md');
+const MARKDOWN_OUT = path.join(REPO_ROOT, 'docs', 'API-REFERENCE.md');
+const OPENAPI_OUT = path.join(REPO_ROOT, 'docs', 'openapi.json');
 const INDEX_TS = path.join(REPO_ROOT, 'api', 'src', 'index.ts');
-
-/** Middleware we recognise, and what it means for a caller. */
-const GUARDS: Record<string, string> = {
-  requireAuth: 'admin',
-  validateServerToken: 'server token',
-  validateEventToken: 'server token',
-};
-
-interface Endpoint {
-  method: string;
-  path: string;
-  guards: string[];
-}
-
-interface Group {
-  title: string;
-  prefix: string;
-  description: string;
-  endpoints: Endpoint[];
-}
-
-// Express layer internals. Typed loosely on purpose: this is a private shape,
-// and pinning it exactly would only turn an Express upgrade into a type error
-// instead of the runtime check below, which explains itself far better.
-interface Layer {
-  name?: string;
-  route?: {
-    path: string | string[];
-    methods: Record<string, boolean>;
-    stack: Array<{ name?: string }>;
-  };
-}
-
-/**
- * Walk one router in registration order.
- *
- * Router-level middleware (`router.use(requireAuth)`) applies to everything
- * registered *after* it, so guards accumulate as we go rather than being read
- * per route. Several routers rely on that — `teams`, `settings` and `servers`
- * guard the whole file with a single `use`, while `matches` guards route by
- * route, and `tournament` and `players` do both, switching partway down.
- */
-function walkRouter(router: unknown): Endpoint[] {
-  const stack = (router as { stack?: Layer[] }).stack;
-
-  if (!Array.isArray(stack)) {
-    throw new Error(
-      'Router has no `stack` array. Express changed its internals, so this ' +
-        'generator can no longer see the routes and would silently emit an ' +
-        'empty reference. Fix the walk in scripts/generate-api-reference.ts.'
-    );
-  }
-
-  const endpoints: Endpoint[] = [];
-  const routerGuards: string[] = [];
-
-  for (const layer of stack) {
-    if (!layer.route) {
-      // Middleware applied to the rest of this router.
-      const guard = layer.name && GUARDS[layer.name];
-      if (guard && !routerGuards.includes(guard)) routerGuards.push(guard);
-      continue;
-    }
-
-    const routeGuards = [...routerGuards];
-    for (const handler of layer.route.stack) {
-      const guard = handler.name && GUARDS[handler.name];
-      if (guard && !routeGuards.includes(guard)) routeGuards.push(guard);
-    }
-
-    const paths = Array.isArray(layer.route.path) ? layer.route.path : [layer.route.path];
-    for (const routePath of paths) {
-      for (const method of Object.keys(layer.route.methods)) {
-        endpoints.push({
-          method: method.toUpperCase(),
-          path: routePath,
-          guards: routeGuards,
-        });
-      }
-    }
-  }
-
-  return endpoints;
-}
 
 /**
  * Routes declared on the app rather than on a router — `/health` and friends.
  *
- * These are read out of index.ts as text. They are a handful of top-level
- * calls with literal paths, and lifting them into a router purely so this
- * script could import them would be tail-wagging-dog; reading them keeps them
- * in the reference and keeps the drift visible.
+ * These are read out of index.ts as text. They are a handful of top-level calls
+ * with literal paths, and lifting them into a router purely so this script
+ * could import them would be tail-wagging-dog. (The OpenAPI side does not need
+ * this: they already carry `@openapi` blocks, which swagger-jsdoc picks up.)
  */
 function appLevelEndpoints(): Endpoint[] {
   const source = fs.readFileSync(INDEX_TS, 'utf8');
@@ -135,20 +58,15 @@ function appLevelEndpoints(): Endpoint[] {
   return endpoints;
 }
 
-function describeGuards(guards: string[]): string {
-  if (guards.length === 0) return 'public';
-  return guards.join(' + ');
-}
-
-function renderGroup(group: Group): string {
+function renderGroup(group: EndpointGroup): string {
   if (group.endpoints.length === 0) return '';
 
   const rows = group.endpoints
     .map((e) => {
-      // `/` as a router path means the prefix itself — except in the
-      // app-level group, which has no prefix, where `/` is the real path.
-      const full = e.path === '/' ? group.prefix || '/' : `${group.prefix}${e.path}`;
-      return `| \`${e.method}\` | \`${full}\` | ${describeGuards(e.guards)} |`;
+      const auth = e.shadowed
+        ? `~~${describeGuards(e.guards)}~~ **shadowed**`
+        : describeGuards(e.guards);
+      return `| \`${e.method}\` | \`${e.path}\` | ${auth} |`;
     })
     .join('\n');
 
@@ -164,10 +82,10 @@ function renderGroup(group: Group): string {
   ].join('\n');
 }
 
-function render(groups: Group[], total: number): string {
-  const guarded = groups
-    .flatMap((g) => g.endpoints)
-    .filter((e) => e.guards.length > 0).length;
+function renderMarkdown(groups: EndpointGroup[], total: number): string {
+  const all = groups.flatMap((g) => g.endpoints);
+  const guarded = all.filter((e) => e.guards.length > 0 && !e.shadowed).length;
+  const shadowed = all.filter((e) => e.shadowed);
 
   return `<!--
   GENERATED FILE — DO NOT EDIT BY HAND.
@@ -186,7 +104,8 @@ Every endpoint this API serves — ${total} of them, ${guarded} behind auth —
 read directly from the routers rather than written down, so it cannot drift.
 
 For *how* to authenticate a bot or script, and a task-oriented tour of the
-endpoints worth using, see [API.md](API.md). This file is the index.
+endpoints worth using, see [API.md](API.md). To generate a client, use
+[openapi.json](openapi.json) — same walk, machine-readable.
 
 ## Reading the Auth column
 
@@ -201,27 +120,86 @@ the caller's identity from a cookie and change what they return, or reject the
 action further in — map veto is the notable one, since actions are attributed
 to a player. Read the handler before assuming an endpoint is anonymous.
 
+**shadowed** marks a registration that never runs: the same method and path was
+registered earlier, and Express matches in registration order. It is dead code,
+and the dangerous kind — it reads as though it were in force. Where a shadowed
+row claims different auth from the row above it, the row above is what answers.
+${
+  shadowed.length === 0
+    ? ''
+    : `\nCurrently shadowed:\n\n${shadowed
+        .map((e) => `- \`${e.method} ${e.path}\``)
+        .join('\n')}\n`
+}
 ## Endpoints
 
 ${groups.map(renderGroup).filter(Boolean).join('\n')}`;
 }
 
+/**
+ * Structural sanity check on the spec before it is written.
+ *
+ * Deliberately dependency-free rather than pulling in a full OpenAPI validator:
+ * the failure modes that actually happen here are a walk that silently returns
+ * nothing, an Express-style `:param` leaking into a path, and a path parameter
+ * used but not declared — which makes generated clients fail at runtime rather
+ * than at codegen. A schema validator catches the first two and is quiet about
+ * the third.
+ */
+function assertSpecIsSound(spec: Record<string, unknown>): void {
+  const paths = (spec.paths ?? {}) as Record<string, Record<string, unknown>>;
+  const problems: string[] = [];
+
+  if (Object.keys(paths).length === 0) {
+    problems.push('the spec has no paths at all');
+  }
+
+  for (const [routePath, operations] of Object.entries(paths)) {
+    if (!routePath.startsWith('/')) {
+      problems.push(`path "${routePath}" does not start with "/"`);
+    }
+    if (routePath.includes(':')) {
+      problems.push(
+        `path "${routePath}" uses Express-style ":param" — OpenAPI wants "{param}". ` +
+          'An `@openapi` block is probably written with the wrong syntax.'
+      );
+    }
+
+    const templated = [...routePath.matchAll(/\{([^}]+)\}/g)].map((m) => m[1]);
+
+    for (const [method, operation] of Object.entries(operations)) {
+      const op = operation as { parameters?: Array<Record<string, unknown>> };
+      const declared = new Set(
+        (op.parameters ?? [])
+          .filter((param) => param.in === 'path')
+          .map((param) => param.name as string)
+      );
+      for (const name of templated) {
+        if (!declared.has(name)) {
+          problems.push(`${method.toUpperCase()} ${routePath}: path parameter "${name}" is not declared`);
+        }
+      }
+    }
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `Refusing to write a malformed OpenAPI spec:\n  - ${problems.join('\n  - ')}`
+    );
+  }
+}
+
 function main(): void {
   const check = process.argv.includes('--check');
 
-  const groups: Group[] = [
+  const groups: EndpointGroup[] = [
     {
       title: 'Health and docs',
       prefix: '',
       description: 'Served by the app itself rather than a router.',
       endpoints: appLevelEndpoints(),
     },
-    ...routeTable.map((mount) => ({
-      title: mount.title,
-      prefix: mount.prefix,
-      description: mount.description,
-      endpoints: walkRouter(mount.router),
-    })),
+    ...collectRouterGroups(),
   ];
 
   const total = groups.reduce((n, g) => n + g.endpoints.length, 0);
@@ -233,30 +211,45 @@ function main(): void {
     );
   }
 
-  const output = render(groups, total);
-  const existing = fs.existsSync(OUTPUT) ? fs.readFileSync(OUTPUT, 'utf8') : null;
+  const markdown = renderMarkdown(groups, total);
+
+  const specObject = buildOpenApiSpec();
+  assertSpecIsSound(specObject);
+  const spec = `${JSON.stringify(specObject, null, 2)}\n`;
+
+  const outputs: Array<{ file: string; content: string; label: string }> = [
+    { file: MARKDOWN_OUT, content: markdown, label: 'docs/API-REFERENCE.md' },
+    { file: OPENAPI_OUT, content: spec, label: 'docs/openapi.json' },
+  ];
 
   if (check) {
-    if (existing === output) {
-      console.log(`docs/API-REFERENCE.md is up to date (${total} endpoints).`);
+    const stale = outputs.filter(
+      (o) => !fs.existsSync(o.file) || fs.readFileSync(o.file, 'utf8') !== o.content
+    );
+
+    if (stale.length === 0) {
+      console.log(`API docs are up to date (${total} endpoints).`);
       return;
     }
+
     console.error(
-      'docs/API-REFERENCE.md is out of date with the routers.\n' +
+      `Out of date with the routers: ${stale.map((o) => o.label).join(', ')}.\n` +
         'Run `yarn docs:api` and commit the result.'
     );
     process.exitCode = 1;
     return;
   }
 
-  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
-  fs.writeFileSync(OUTPUT, output);
+  fs.mkdirSync(path.dirname(MARKDOWN_OUT), { recursive: true });
+  for (const output of outputs) fs.writeFileSync(output.file, output.content);
+
   console.log(
-    `Wrote docs/API-REFERENCE.md — ${total} endpoints across ${groups.length} groups.`
+    `Wrote docs/API-REFERENCE.md and docs/openapi.json — ${total} endpoints ` +
+      `across ${groups.length} groups.`
   );
 }
 
 main();
-// Importing the routers pulls in services that hold timers and a database
-// pool, so the process would otherwise sit there with nothing to do.
+// Importing the routers pulls in services that hold timers and a database pool,
+// so the process would otherwise sit there with nothing to do.
 process.exit(process.exitCode ?? 0);

--- a/tests/api/openapi-spec.spec.ts
+++ b/tests/api/openapi-spec.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { collectRouterGroups, toOpenApiPath } from '../../api/src/utils/routeIntrospection';
+
+/**
+ * The OpenAPI spec, against the routers it claims to describe.
+ *
+ * The spec is the contract anything outside this repo builds against — a bot
+ * generates a typed client from it. An incomplete spec is a bot that cannot
+ * call an endpoint that exists; a spec with the wrong `security` is worse,
+ * because a client is generated that omits a credential and 401s at runtime for
+ * no visible reason.
+ *
+ * @tag api
+ * @tag docs
+ */
+
+const COMMITTED = path.join(__dirname, '..', '..', 'docs', 'openapi.json');
+
+interface Spec {
+  paths: Record<string, Record<string, { security?: Array<Record<string, string[]>> }>>;
+  components?: { securitySchemes?: Record<string, unknown> };
+}
+
+function operationKeys(spec: Spec): string[] {
+  return Object.entries(spec.paths)
+    .flatMap(([p, methods]) => Object.keys(methods).map((m) => `${m} ${p}`))
+    .sort();
+}
+
+/** Every route that actually answers — shadowed registrations never run. */
+function liveRouterEndpoints() {
+  return collectRouterGroups()
+    .flatMap((g) => g.endpoints)
+    .filter((e) => !e.shadowed);
+}
+
+test.describe('OpenAPI spec', () => {
+  test('describes every endpoint the routers mount', {
+    tag: ['@api', '@docs'],
+  }, async ({ request }) => {
+    const response = await request.get('/api-docs.json');
+    expect(response.ok()).toBeTruthy();
+    const spec = (await response.json()) as Spec;
+
+    const documented = new Set(operationKeys(spec));
+    const missing = liveRouterEndpoints()
+      .map((e) => `${e.method.toLowerCase()} ${toOpenApiPath(e.path)}`)
+      .filter((key) => !documented.has(key));
+
+    expect(missing, 'every mounted route should appear in the spec').toEqual([]);
+  });
+
+  test('the committed spec matches what the server serves', {
+    tag: ['@api', '@docs'],
+  }, async ({ request }) => {
+    // Otherwise the file people generate clients from drifts from the API,
+    // which is the exact failure this whole approach exists to prevent.
+    const live = (await (await request.get('/api-docs.json')).json()) as Spec;
+    const committed = JSON.parse(fs.readFileSync(COMMITTED, 'utf8')) as Spec;
+
+    expect(operationKeys(committed)).toEqual(operationKeys(live));
+  });
+
+  test('admin endpoints declare a security requirement', {
+    tag: ['@api', '@docs'],
+  }, async ({ request }) => {
+    const spec = (await (await request.get('/api-docs.json')).json()) as Spec;
+
+    const unguarded = liveRouterEndpoints()
+      .filter((e) => e.guards.includes('admin'))
+      .filter((e) => {
+        const op = spec.paths[toOpenApiPath(e.path)]?.[e.method.toLowerCase()];
+        return !op?.security || op.security.length === 0;
+      })
+      .map((e) => `${e.method} ${e.path}`);
+
+    expect(unguarded, 'admin-guarded routes must declare security').toEqual([]);
+  });
+
+  test('a public endpoint is not marked as requiring auth', {
+    tag: ['@api', '@docs'],
+  }, async ({ request }) => {
+    const spec = (await (await request.get('/api-docs.json')).json()) as Spec;
+
+    // Genuinely public and heavily used by bots — if this grew a security
+    // requirement, generated clients would start demanding a token for it.
+    expect(spec.paths['/api/matches']?.get?.security).toBeUndefined();
+  });
+
+  test('a shadowed route is described by the registration that actually runs', {
+    tag: ['@api', '@docs'],
+  }, async ({ request }) => {
+    const spec = (await (await request.get('/api-docs.json')).json()) as Spec;
+
+    // GET /api/tournament/:id/leaderboard is registered twice — once before
+    // router.use(requireAuth) and once after. Express answers with the first,
+    // so the spec must say public. Describing the shadowed one would tell every
+    // generated client to send a credential the endpoint never asks for.
+    const op = spec.paths['/api/tournament/{id}/leaderboard']?.get;
+    expect(op, 'the leaderboard should be in the spec').toBeTruthy();
+    expect(op?.security).toBeUndefined();
+
+    const response = await request.get('/api/tournament/1/leaderboard');
+    expect(response.status(), 'and it should really answer without auth').not.toBe(401);
+  });
+
+  test('every security scheme a path references is defined', {
+    tag: ['@api', '@docs'],
+  }, async ({ request }) => {
+    const spec = (await (await request.get('/api-docs.json')).json()) as Spec;
+    const defined = new Set(Object.keys(spec.components?.securitySchemes ?? {}));
+
+    const dangling = new Set<string>();
+    for (const methods of Object.values(spec.paths)) {
+      for (const op of Object.values(methods)) {
+        for (const requirement of op.security ?? []) {
+          for (const name of Object.keys(requirement)) {
+            if (!defined.has(name)) dangling.add(name);
+          }
+        }
+      }
+    }
+
+    expect([...dangling], 'security schemes must be declared in components').toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

#183 gave people a complete endpoint list **to read**. It did nothing for a program: a bot in another repo still hand-writes its calls against a Markdown table, which is the drift problem again with extra steps.

The OpenAPI spec was the obvious answer and wasn't usable — `swagger-jsdoc` only sees endpoints somebody annotated:

| | Before | After |
| --- | --- | --- |
| Operations in spec | 57 | **184** (all of them) |
| Endpoints with correct `security` | partial | **all** |
| Routers with zero coverage | `rcon`, `players`, `servers`, `matches`, `teams`, `veto` | none |

## What

The router walk supplies the skeleton for every endpoint; a hand-written `@openapi` block wins wherever one exists, so the request/response detail people already wrote is kept.

`docs/openapi.json` is **committed**, so a client can be generated without a running MAT:

```bash
npx openapi-typescript docs/openapi.json -o src/mat-api.d.ts
```

Verified end to end — 7,201 lines of types, and the spec passes `swagger-parser` validation. A live instance serves the byte-identical document at `/api-docs.json`; a test asserts that.

The walk moves to `api/src/utils/routeIntrospection.ts` so the Markdown generator, the committed spec and the running server share one implementation rather than three that agree until they don't.

**`security` always comes from the middleware, never from an annotation.** An annotation claiming an endpoint is open when `requireAuth` guards it is worse than no annotation, because a generated client believes it.

## ⚠️ Two things this turned up

**Shadowed routes.** `GET /api/tournament/:id/leaderboard` is registered twice — once *before* `router.use(requireAuth)` and once after. Express matches the first, so **the endpoint is public** and the admin-looking registration is dead code. `DELETE /api/matches/:slug` is likewise doubled.

Both are now marked **shadowed** in the reference, and the spec describes the registration that *actually runs* — describing the other would tell every generated client to send a credential the endpoint never asks for. Left in place: deleting dead routes isn't a docs change, and the leaderboard being public may well be intended. Worth a look.

**Malformed annotations.** `templates.ts` wrote its `@openapi` paths as `/api/templates/:id`, which isn't OpenAPI syntax — those three endpoints appeared *twice* in the spec, once as a ghost path and once generated. Fixed, and the generator now refuses to write a spec containing Express-style params, an undeclared path parameter, or no paths at all (verified by reintroducing the bug and watching it exit 1).

## Testing

New `tests/api/openapi-spec.spec.ts` — 6 tests: every mounted route appears; committed spec matches what the server serves; admin routes declare security; a public route isn't marked as requiring auth; a shadowed route is described by the registration that runs (and really answers without auth); every referenced security scheme is defined.

Full `tests/api`: **116 passed**. The one failure (`player-page-permissions`) needs the built SPA, absent when running the API from source — pre-existing, reproduced on an unmodified checkout earlier in this work.

Typecheck ratchet: no new errors. `yarn docs:api:check` gates both generated files in CI.

## Note on scope

Paths, methods, path parameters and `security` are complete and correct for all 184 operations. Request/response **schemas** still only exist where someone wrote an annotation (~a third). The generated stubs say so and point at the handler — documented in `docs/API.md` so nobody over-trusts a generated response type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)